### PR TITLE
Add Security Features page, and add Mbed TLS in SSL/TLS page

### DIFF
--- a/docs/source/overview/features.rst
+++ b/docs/source/overview/features.rst
@@ -9,5 +9,6 @@ Features (Datasheet)
    features_nat
    features_media
    features_video
+   features_security
    features_codec
    features_media_devs

--- a/docs/source/overview/features_security.rst
+++ b/docs/source/overview/features_security.rst
@@ -1,0 +1,22 @@
+Security Features
+-----------------------
+
+TLS/SSL
+~~~~~~~~~~~~~~~~~~~~~~
+- See :doc:`/specific-guides/security/ssl` specific guide.
+
+
+SIP Security
+~~~~~~~~~~~~~~~~~~~~~~
+Security related features in PJSIP, among other things:
+
+- SIPS
+- TLS transport
+- Various authentication: digest, AKA, AKA-v2, OAuth 2.0
+
+See :doc:`/overview/features_sip` for details.
+
+
+Media Security
+~~~~~~~~~~~~~~~~~~~~~~
+- See :doc:`/specific-guides/security/srtp` specific guide.

--- a/docs/source/overview/features_sip.rst
+++ b/docs/source/overview/features_sip.rst
@@ -13,7 +13,7 @@ Base specs
 - Core methods: :rfc:`3261`:
   INVITE, CANCEL, BYE, REGISTER, OPTIONS, INFO
 - Digest authentication (:rfc:`2617`)
-- Encoding and parsing of Bearer authenticaion (OAuth 2.0)
+- Encoding and parsing of Bearer authentication (OAuth 2.0)
   (:rfc:`8898`)
 
 Transports

--- a/docs/source/specific-guides/security/ssl.rst
+++ b/docs/source/specific-guides/security/ssl.rst
@@ -17,6 +17,7 @@ The TLS support in PJSIP requires one of the following:
 - GnuTLS: :issue:`2082`
 - Mac/iOS native backend: :issue:`2482` and :issue:`2185`
 - Windows native SChannel SSP backend: :issue:`3867`
+- Mbed TLS for embedded systems: :issue:`4295`
 
 This page mostly describes TLS usage with OpenSSL. For other backends, please refer to the GitHub issues/PR above.
 


### PR DESCRIPTION
As the title says:

- Add [Security Features](https://docs.pjsip.org/en/latest/overview/features_security.html) (link not available until document is generated) under [Features](https://docs.pjsip.org/en/latest/overview/features.html) page.
- Add Mbed TLS in [SSL/TLS](https://docs.pjsip.org/en/latest/specific-guides/security/ssl.html) page. Support for Mbed TLS is done in pjsip/pjproject#4295
