### PR TITLE
Revise IPv6/NAT64 and IP change guides

### DIFF
--- a/docs/source/specific-guides/network_nat/ip_change.rst
+++ b/docs/source/specific-guides/network_nat/ip_change.rst
@@ -33,7 +33,7 @@ When invoked, the stack will:
 1. Restart the SIP transport listener
 
    This will restart TCP/TLS listener no matter whether they are enabled or not when the transport were created. If you don't have any use of the listener, you can disable this.
-   However, if you do need this, then on some platform (e.g: on IOS), some delay is needed when restarting the the listener.
+   However, if you do need this, then on some platform (e.g: on IOS), some delay is needed when restarting the listener.
 
    ref: :cpp:any:`pjsua_ip_change_param::restart_listener` and :cpp:any:`pjsua_ip_change_param::restart_lis_delay`.
 
@@ -51,7 +51,7 @@ When invoked, the stack will:
 
 4. Hangup active calls or continue the call by sending re-INVITE
 
-   You can either hangup or maintain the ongoing/active calls. If you intend to maintain the active calls, updating dialog's contact URI is required. This can be done by specifying :cpp:any:`pjsua_callback::PJSUA_CALL_UPDATE_CONTACT` to the reinvite flags. Note that, hanging up calls might be inevitable on some cases, please see
+   You can either hangup or maintain the ongoing/active calls. If you intend to maintain the active calls, updating dialog's contact URI is required. This can be done by specifying :cpp:any:`PJSUA_CALL_UPDATE_CONTACT` to the reinvite flags. Note that, hanging up calls might be inevitable on some cases, please see
    **Network change to the same IP address type. (IPv4 to IPv4) or (IPv6 to IPv6)** section below.
 
    ref: :cpp:any:`pjsua_ip_change_acc_cfg::hangup_calls` and :cpp:any:`pjsua_ip_change_acc_cfg::reinvite_flags` in :cpp:class:`pjsua_acc_config::ip_change_cfg`
@@ -68,7 +68,6 @@ To monitor the progress of IP change handling, application can use :cpp:member:`
 
 Related to maintaining a call during IP change, there are some scenarios that are currently not implemented by IP change mechanism, so application needs to handle manually: If IP change occurs during SDP negotiation (and it is not completed yet, so there cannot be another SDP offer), updating such call needs to be done in two steps:
 
-#. Update Contact header, so remote endpoint can send its SDP answer to our new contact address, i.e: use UPDATE without SDP offer (:cpp:any:`PJSUA_CALL_NO_SDP_OFFER` :flag). Note that, not every endpoint supports UPDATE. Contact is used by remote to resolve target before sending new requests. If proxy is used, then you can probably skip this.
 #. Update Contact header, so remote endpoint can send its SDP answer to our new contact address, i.e: use UPDATE without SDP offer (:cpp:any:`PJSUA_CALL_NO_SDP_OFFER` flag). Note that, not every endpoint supports UPDATE. Contact is used by remote to resolve target before sending new requests. If proxy is used, then you can probably skip this.
 #. Update local media transport after SDP answer is received, by sending UPDATE/re-INVITE with :cpp:any:`PJSUA_CALL_REINIT_MEDIA` flag.
 
@@ -87,12 +86,19 @@ Update contact process (re-Registration) and call handling (hang-up or continue 
 Network change to a different IP address type. (IPv4 to IPv6) or (IPv6 to IPv4)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As you already know, IPv6 needs specific account configuration as described [wiki:ipv6 here].
-On the case of IP address type change, then additional steps are required from application.
+IPv6 needs specific account configuration — see
+:ref:`IPv6 modes and defaults <ipv6_modes>` in the
+:doc:`IPv6 and NAT64 guide <ipv6>` for the mode reference.
+On the case of IP address type change, additional steps are required
+from the application:
 
 #. Once application detects a network with IP address type change, a new transport might need to be created.
 
-#. Once the transport is available, modify account's transport preference setting if necessary by calling :cpp:func:`pjsua_acc_modify()`, and then call :cpp:func:`pjsua_handle_ip_change()`.
+#. Once the transport is available, modify the account's IP version
+   preferences if necessary by calling :cpp:func:`pjsua_acc_modify()`,
+   and then call :cpp:func:`pjsua_handle_ip_change()`.
+
+PJSUA-LIB:
 
 .. code-block:: c
 
@@ -113,11 +119,7 @@ On the case of IP address type change, then additional steps are required from a
 
         // ******************************************************
         // ** For PJSIP 2.14 and above:
-        // Set SIP use to PJSUA_IPV6_ENABLED_USE_IPV6_ONLY
-        // Important: if you use PREFER_IPV6, existing calls that
-        // use IPv4 will still use IPv4.
-        acc_cfg.ipv6_sip_use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
-        // Set media use to USE_IPV6_ONLY or PREFER_IPV6.
+        acc_cfg.ipv6_sip_use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
         acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
         // ** For PJSIP earlier than 2.14:
         // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
@@ -125,8 +127,8 @@ On the case of IP address type change, then additional steps are required from a
 
         // acc_cfg.ip_change_cfg.hangup_calls = PJ_TRUE;
 
-        // Available in #3910, to prevent pjsua_acc_modify()
-        // to prematurely send registration
+        // Available since #3910, prevents pjsua_acc_modify() from
+        // prematurely sending a REGISTER on the old (dead) transport.
         acc_cfg.disable_reg_on_modify = PJ_TRUE;
         pjsua_acc_modify(acc_id, &acc_cfg);
 
@@ -135,6 +137,38 @@ On the case of IP address type change, then additional steps are required from a
         pjsua_ip_change_param_default(&param);
         pjsua_handle_ip_change(param);
     }
+
+PJSUA2 (keep your own ``AccountConfig`` around since the class doesn't
+expose a getter):
+
+.. code-block:: c++
+
+    void ip_change_to_ip6(Account *acc, AccountConfig &acc_cfg)
+    {
+        // Create new IPv6 transport if needed; e.g. TLS6
+        Endpoint &ep = Endpoint::instance();
+        TransportConfig tp_cfg;
+        ep.transportCreate(PJSIP_TRANSPORT_TLS6, tp_cfg);
+
+        acc_cfg.sipConfig.ipv6Use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.mediaConfig.ipv6Use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+
+        // Prevent modify() from sending a REGISTER on the old transport.
+        acc_cfg.regConfig.disableRegOnModify = true;
+        acc->modify(acc_cfg);
+
+        IpChangeParam param;
+        ep.handleIpChange(param);
+    }
+
+.. note::
+
+   The example forces ``USE_IPV6_ONLY`` to tear down existing IPv4
+   state entirely. If you set ``ipv6_sip_use = PREFER_IPV6`` instead,
+   the account is dual-stack and **existing calls that were negotiated
+   over IPv4 continue to run over IPv4** — the new preference only
+   affects subsequent outgoing offers/requests. Choose
+   ``USE_IPV6_ONLY`` when the old family is truly gone.
 
 
 

--- a/docs/source/specific-guides/network_nat/ip_change.rst
+++ b/docs/source/specific-guides/network_nat/ip_change.rst
@@ -33,7 +33,7 @@ When invoked, the stack will:
 1. Restart the SIP transport listener
 
    This will restart TCP/TLS listener no matter whether they are enabled or not when the transport were created. If you don't have any use of the listener, you can disable this.
-   However, if you do need this, then on some platform (e.g: on IOS), some delay is needed when restarting the listener.
+   However, if you do need this, then on some platform (e.g: on iOS), some delay is needed when restarting the listener.
 
    ref: :cpp:any:`pjsua_ip_change_param::restart_listener` and :cpp:any:`pjsua_ip_change_param::restart_lis_delay`.
 

--- a/docs/source/specific-guides/network_nat/ipv6.rst
+++ b/docs/source/specific-guides/network_nat/ipv6.rst
@@ -8,20 +8,24 @@ IPv6 and NAT64 support
 Availability
 ------------
 
-IPv6 support is available in the following platforms: 
+IPv6 support is available on the following platforms:
 
-- Windows families, e.g.: Windows 7/8/10, Windows XP, Windows Server 2003, and Windows Vista, using Microsoft Platform SDK for Windows Server 2003 SP1
-- Linux/Unix/MacOS X with GNU development systems, IPv6 features are detected by the ``./configure`` script. 
+- Windows
+- Linux / Unix / macOS
 - iOS
 - Android
-- Symbian (deprecated)
+
+Both the GNU autotools (``./configure``) and CMake builds auto-detect
+the host's IPv6 socket capabilities (``getaddrinfo``, ``IPV6_V6ONLY``)
+at configure time. ``PJ_HAS_IPV6`` itself remains an explicit opt-in
+via ``config_site.h`` (see below).
 
 
 IPv6 Support in pjlib
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The work for adding IPv6 support in pjlib is documented by ticket :pr:`415`.
 
-pjlib supports IPv6, but for now this has to be enabled in ``pj/config_site.h``:
+pjlib supports IPv6; enable it in ``pj/config_site.h``:
 
 .. code-block:: c
 
@@ -30,7 +34,7 @@ pjlib supports IPv6, but for now this has to be enabled in ``pj/config_site.h``:
 **Socket Addresses**:
 
 - An IPv4 socket address is represented by :cpp:any:`pj_sockaddr_in` structure, while an IPv6 socket address is represented by :cpp:any:`pj_sockaddr_in6` structure. The :cpp:any:`pj_sockaddr` is a union which may contain IPv4 or IPv6 socket address, depending on the address family field. 
-- Various new socket address API's have been added which can work on both IPv4 and IPv6 address, such as: 
+- pjlib provides socket address APIs that work on both IPv4 and IPv6, including:
 
     - :cpp:any:`pj_inet_pton()`
     - :cpp:any:`pj_inet_ntop()`
@@ -52,23 +56,23 @@ pjlib supports IPv6, but for now this has to be enabled in ``pj/config_site.h``:
 
 **Address Resolution API**:
 
-- A new API :cpp:any:`pj_getaddrinfo()` has been added to resolve both IPv4 and IPv6 addresses, in addition to existing :cpp:any:`pj_gethostbyname()` API which resolves IPv4 address. 
-- The :cpp:any:`pj_gethostip()` and :cpp:any:`pj_getdefaultipinterface()` API has been modified to take an additional address family argument.
+- Use :cpp:any:`pj_getaddrinfo()` to resolve both IPv4 and IPv6 addresses. The older :cpp:any:`pj_gethostbyname()` is IPv4-only and is kept for backward compatibility.
+- :cpp:any:`pj_gethostip()` and :cpp:any:`pj_getdefaultipinterface()` take an address family argument.
 
 **IP Helper API:**
 
-- The :cpp:any:`pj_enum_ip_interface()` API has been modified to take an additional address family argument.
+- :cpp:any:`pj_enum_ip_interface()` takes an address family argument.
 
 
 IPv6 Support in pjsip
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The work for adding IPv6 support in pjlib is documented by ticket :pr:`421`.
+The work for adding IPv6 support in pjsip is documented by ticket :pr:`421`.
 
 
 **IPv6 SIP Transport**:
 
-- The SIP UDP transport now supports IPv6 sockets, and new API's have been added to facilitate IPv6 transport creation (:cpp:any:`pjsip_udp_transport_start6()` and :cpp:any:`pjsip_udp_transport_attach2()`). Note that if application wants to support both IPv4 and IPv6 UDP transports, two separate UDP transport instances must be created, one for each address family. 
-- The SIP TCP and TLS transports also support IPv6 sockets since version 2.1 (ticket :pr:`1585`).
+- The SIP UDP transport supports IPv6 sockets via :cpp:any:`pjsip_udp_transport_start6()` and :cpp:any:`pjsip_udp_transport_attach2()`. To serve both IPv4 and IPv6 UDP, create two separate UDP transport instances, one per address family.
+- The SIP TCP and TLS transports also support IPv6 sockets (ticket :pr:`1585`).
 
 
 **IPv6 Address Representation**:
@@ -86,32 +90,146 @@ DNS AAAA resolution will be performed for each DNS SRV record when flag :cpp:any
 
 IPv6 Support in pjmedia (SDP, media transport)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The work for adding IPv6 support in pjmedia is documented by ticket #420.
+The work for adding IPv6 support in pjmedia is documented by ticket :issue:`420`.
 
-The SDP representation has been updated to support IPv6 address, and the
-UDP media transport now also supports IPv6 sockets. There have been some
-*incompatible* changes introduced in pjmedia: 
+The SDP representation and the UDP media transport both support IPv6
+addresses. The following pjmedia fields carry addresses as a
+:cpp:any:`pj_sockaddr` union (either IPv4 or IPv6):
 
-- the :cpp:any:`pjmedia_sock_info::rtp_addr_name` and :cpp:any:`pjmedia_sock_info::rtcp_addr_name` fields (which describes the media transport address information) has been changed to use :cpp:any:`pj_sockaddr` union rather than :cpp:any:`pj_sockaddr_in` structure which is specific to IPv4, 
-- the :cpp:any:`pjmedia_stream_info::rem_addr` and :cpp:any:`pjmedia_stream_info::rem_rtcp` fields also have been changed to use :cpp:any:`pj_sockaddr` union.
+- :cpp:any:`pjmedia_sock_info::rtp_addr_name` and
+  :cpp:any:`pjmedia_sock_info::rtcp_addr_name`.
+- :cpp:any:`pjmedia_stream_info::rem_addr` and
+  :cpp:any:`pjmedia_stream_info::rem_rtcp`.
 
 
 IPv6 Support in pjnath (ICE)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The work for adding IPv6 support in pjnath is documented by ticket #422.
+The work for adding IPv6 support in pjnath is documented by ticket :issue:`422`.
 
-STUN and TURN transports support IPv6 already, and now ICE stream
-transport support IPv6 too. Also, ICE stream transport has been updated
-to be able to have multiple STUN and TURN transports and each STUN/TURN
-transport may use either IPv4 and IPv6.
+STUN, TURN, and ICE stream transports all support IPv6. An ICE stream
+transport may carry multiple STUN and TURN transports, each of which
+may use either IPv4 or IPv6 independently.
 
-Modifications in :cpp:any:`pj_ice_strans_cfg`: 
+Fields in :cpp:any:`pj_ice_strans_cfg`:
 
 - Deprecated ``af`` field, if it is set, the value will be ignored, address family setting is now specified via STUN/TURN transport setting, i.e: ``stun_tp.af`` and ``turn_tp.af``. 
 - Deprecated ``stun`` and ``turn`` fields, but for backward compatibility, those fields will still be used only if ``stun_tp_cnt`` and/or ``turn_tp_cnt`` is set to zero. 
 - Added ``stun_tp`` and ``turn_tp`` as replacement of ``stun`` and ``turn`` respectively, and they are array so application can have multiple STUN/TURN transports. 
-- Added function :cpp:any:`pj_ice_strans_stun_cfg_default()` and :cpp:any:`pj_ice_strans_stun_cfg_default()` to initialize ``stun_tp`` and ``turn_tp`` respectively with default values. 
+- Added function :cpp:any:`pj_ice_strans_stun_cfg_default()` and :cpp:any:`pj_ice_strans_turn_cfg_default()` to initialize ``stun_tp`` and ``turn_tp`` respectively with default values.
 - Added compile-time settings :c:macro:`PJ_ICE_MAX_STUN` and :c:macro:`PJ_ICE_MAX_TURN` to specify maximum number of STUN/TURN transports in each ICE component.
+
+
+.. _ipv6_modes:
+
+IPv6 Modes and Defaults (PJSIP 2.14+)
+--------------------------------------
+
+Starting from PJSIP 2.14 (:pr:`3590`), an account carries two independent
+IPv6 preferences:
+
+- :cpp:any:`pjsua_acc_config::ipv6_sip_use` — IP version preference for
+  SIP signalling.
+- :cpp:any:`pjsua_acc_config::ipv6_media_use` — IP version preference for
+  RTP/RTCP media.
+
+In PJSUA2 these map to ``AccountConfig::sipConfig.ipv6Use`` and
+``AccountConfig::mediaConfig.ipv6Use`` respectively.
+
+The two preferences are intentionally independent because signalling
+and media usually traverse different paths:
+
+- **SIP signalling** is endpoint-to-server (PBX, SBC, registrar). The
+  address family is largely determined by what the provider supports,
+  so ``ipv6_sip_use`` is a deployment decision against a single known
+  peer.
+- **RTP/RTCP media** is peer-to-peer (endpoint-to-endpoint, possibly
+  relayed through a TURN server or media gateway). The remote peer's
+  address family varies per call and is often outside your control, so
+  ``ipv6_media_use`` is set to match the population of remotes your
+  endpoint talks to (typically dual-stack).
+
+Because of this split, it is common and valid to have, for example,
+IPv6-only signalling (``USE_IPV6_ONLY``) to a cloud SIP provider while
+media stays dual-stack (``PREFER_IPV4`` or ``PREFER_IPV6``) so calls
+to legacy IPv4 peers still work.
+
+The :cpp:any:`pjsua_ipv6_use` enum values:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Value
+     - Meaning
+   * - ``PJSUA_IPV6_DISABLED``
+     - IPv4 only; IPv6 addresses/candidates are not used.
+   * - ``PJSUA_IPV6_ENABLED_NO_PREFERENCE``
+     - IPv6 is enabled; the actual IP version comes from whatever the OS
+       resolver returns (typically RFC 6724 destination address
+       selection). Legacy alias ``PJSUA_IPV6_ENABLED`` has the same
+       meaning.
+   * - ``PJSUA_IPV6_ENABLED_PREFER_IPV4``
+     - Dual stack; the outgoing offer/request prefers IPv4 when both
+       are available.
+   * - ``PJSUA_IPV6_ENABLED_PREFER_IPV6``
+     - Dual stack; the outgoing offer/request prefers IPv6 when both
+       are available.
+   * - ``PJSUA_IPV6_ENABLED_USE_IPV6_ONLY``
+     - IPv6 only; IPv4 addresses/candidates are not used. Required for
+       NAT64-only networks.
+
+Preference only applies to the **outgoing** direction. For incoming
+messages or offers, PJSIP accepts whichever IP version the remote
+actually used, provided that family is enabled by the account's
+configuration. In practice this means:
+
+- ``DISABLED`` excludes IPv6 in both directions; an incoming IPv6
+  offer on that account is rejected.
+- ``USE_IPV6_ONLY`` excludes IPv4 in both directions; an incoming
+  IPv4 offer on that account is rejected.
+- The three dual-stack modes (``ENABLED_NO_PREFERENCE``,
+  ``PREFER_IPV4``, ``PREFER_IPV6``) accept either family on incoming.
+
+Defaults are asymmetric:
+
+- ``ipv6_sip_use`` → ``PJSUA_IPV6_ENABLED_NO_PREFERENCE`` (SIP follows
+  DNS/OS resolution).
+- ``ipv6_media_use`` → ``PJSUA_IPV6_ENABLED_PREFER_IPV4`` (media is
+  dual-stack capable but the offer prefers IPv4).
+
+**Choosing a mode**:
+
+- **IPv4-only deployment** — leave both at defaults, or set both to
+  ``DISABLED`` to guarantee no IPv6 code paths are exercised.
+- **Dual-stack deployment, v4-first network** — defaults are fine.
+- **Dual-stack deployment, v6-first SIP provider** — set
+  ``ipv6_sip_use = PJSUA_IPV6_ENABLED_PREFER_IPV6``.
+- **IPv6-only SIP provider** — set both to ``USE_IPV6_ONLY``.
+- **Mobile / NAT64 network** — set both to ``USE_IPV6_ONLY`` and enable
+  ``nat64_opt = PJSUA_NAT64_ENABLED``; see :ref:`ipv6_nat64`. Required
+  for iOS apps submitted to the App Store.
+
+**Best practices for dual-stack deployments**:
+
+- **Use hostnames, not IP literals.** Configure ``id``, ``reg_uri``,
+  ``proxy`` and similar fields with DNS names (``sip:user@example.com``)
+  rather than numeric IP literals. PJSIP's resolver then issues A and
+  AAAA queries and lets the chosen mode decide which address family to
+  use — no change to the account config is needed when the provider
+  adds IPv6 (or vice versa).
+- **Enable ICE for media.** With ICE, every call gathers both IPv4 and
+  IPv6 candidates (plus server-reflexive and relayed candidates when
+  STUN/TURN are configured) and picks whichever pair actually works
+  with the remote. This is the only robust way to connect media across
+  peers whose address families you don't control in advance. See the
+  :doc:`ICE/STUN/TURN documentation <standalone_ice>`.
+- **Provision a dual-stack TURN server.** On networks where direct
+  peer-to-peer connectivity is flaky (cellular, corporate, NAT64), a
+  TURN server that can allocate both IPv4 and IPv6 relays guarantees a
+  fallback path across address families.
+- **Plan for IP changes.** Hand-off between Wi-Fi (often IPv4) and
+  cellular (often IPv6) frequently flips the address family of the
+  endpoint. See :ref:`ipv6_ip_change` below.
 
 
 Enabling IPv6 support in application using PJSUA-LIB
@@ -157,54 +275,121 @@ Here is sample code for IPv6 SIP transport initializations.
         ...
 
 
-**SIP Account**
+**SIP Account (PJSIP 2.14+)**
 
-Starting from PJSIP 2.14, you can configure your account's settings
-:cpp:any:`pjsua_acc_config::ipv6_sip_use` and
-:cpp:any:`pjsua_acc_config::ipv6_media_use` to specify your IP address preference. The options are:
-:cpp:any:`PJSUA_IPV6_DISABLED`, :cpp:any:`PJSUA_IPV6_ENABLED_NO_PREFERENCE`,
-:cpp:any:`PJSUA_IPV6_ENABLED_PREFER_IPV4`, :cpp:any:`PJSUA_IPV6_ENABLED_PREFER_IPV6`,
-:cpp:any:`PJSUA_IPV6_ENABLED_USE_IPV6_ONLY`.
-
-If you are using PJSIP before version 2.14, it is recommended to explicitly bind an IPv6
-account to an IPv6 SIP transport, i.e: via
-:cpp:any:`pjsua_acc_config::transport_id` or :cpp:any:`pjsua_acc_set_transport()`.
-Also, IPv6 usage must be explicitly set for media transport, i.e: via
-:cpp:any:`pjsua_acc_config::ipv6_media_use`.
-
-Here is sample code for setting up account using IPv6 SIP server (for PJSIP earlier than 2.14).
+On 2.14 and later, configure the account's IP version preferences
+directly via :cpp:any:`pjsua_acc_config::ipv6_sip_use` and
+:cpp:any:`pjsua_acc_config::ipv6_media_use`. The runtime will then pick
+an appropriate transport (or create one on demand) based on DNS
+resolution and the chosen mode — no explicit ``transport_id`` binding
+is required in the dual-stack case:
 
 .. code-block:: c
 
-    #define SIP_USER "user" 
-    #define SIP_SERVER "example.com" 
-    //#define SIP_SERVER_IPv6 "[1234::5678]" 
-    #define SIP_PASSWD "pwd"
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_config_default(&acc_cfg);
 
-    pjsua_acc_config acc_cfg; pjsua_acc_config_default(&acc_cfg);
-
-    acc_cfg.id = pj_str("sip:" SIP_USER "@" SIP_SERVER); 
-    acc_cfg.reg_uri = pj_str("sip:" SIP_SERVER); 
-    acc_cfg.cred_count = 1;
-    acc_cfg.cred_info[0].realm = pj_str("*"); 
-    acc_cfg.cred_info[0].scheme = pj_str("digest"); 
-    acc_cfg.cred_info[0].username = pj_str(SIP_USER);
+    acc_cfg.id             = pj_str("sip:user@example.com");
+    acc_cfg.reg_uri        = pj_str("sip:example.com");
+    acc_cfg.cred_count     = 1;
+    acc_cfg.cred_info[0].realm     = pj_str("*");
+    acc_cfg.cred_info[0].scheme    = pj_str("digest");
+    acc_cfg.cred_info[0].username  = pj_str("user");
     acc_cfg.cred_info[0].data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
-    acc_cfg.cred_info[0].data = pj_str(SIP_PASSWD);
+    acc_cfg.cred_info[0].data      = pj_str("pwd");
 
-    /* Bind the account to IPv6 transport */ 
-    acc_cfg.transport_id = udp6_tp_id; 
-    // udp6_tp_id is an UDP IPv6 transport ID, e.g: outputed by
-    // pjsua_transport_create(PJSIP_TRANSPORT_UDP6, …, &udp6_tp_id)
+    /* Dual-stack SIP and media; tune per deployment (see Modes above). */
+    acc_cfg.ipv6_sip_use   = PJSUA_IPV6_ENABLED_NO_PREFERENCE;
+    acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED_PREFER_IPV4;
 
-    /* Enable IPv6 in media transport */ 
+    status = pjsua_acc_add(&acc_cfg, PJ_TRUE, NULL);
+
+The equivalent PJSUA2 setup:
+
+.. code-block:: c++
+
+    AccountConfig acc_cfg;
+    acc_cfg.idUri = "sip:user@example.com";
+    acc_cfg.regConfig.registrarUri = "sip:example.com";
+    AuthCredInfo cred("digest", "*", "user", 0, "pwd");
+    acc_cfg.sipConfig.authCreds.push_back(cred);
+
+    acc_cfg.sipConfig.ipv6Use   = PJSUA_IPV6_ENABLED_NO_PREFERENCE;
+    acc_cfg.mediaConfig.ipv6Use = PJSUA_IPV6_ENABLED_PREFER_IPV4;
+
+    Account *acc = new MyAccount();
+    acc->create(acc_cfg);
+
+**SIP Account (PJSIP < 2.14)**
+
+On older releases, explicitly bind the account to an IPv6 transport
+via :cpp:any:`pjsua_acc_config::transport_id` (or
+:cpp:any:`pjsua_acc_set_transport()`), and set
+``ipv6_media_use = PJSUA_IPV6_ENABLED``:
+
+.. code-block:: c
+
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_config_default(&acc_cfg);
+    /* ... id, reg_uri, cred_info as above ... */
+
+    /* Bind the account to the IPv6 transport created earlier. */
+    acc_cfg.transport_id   = udp6_tp_id;  /* or tcp6_tp_id / tls6_tp_id */
+
+    /* Enable IPv6 for media. */
     acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
 
-    /* Finally */ 
-    status = pjsua_acc_add(&acc_cfg, PJ_TRUE, NULL); 
-    if (status != PJ_SUCCESS)
-        ...
+    status = pjsua_acc_add(&acc_cfg, PJ_TRUE, NULL);
 
+
+.. _ipv6_ip_change:
+
+IPv4 ↔ IPv6 transitions during IP address change
+--------------------------------------------------
+
+Mobile endpoints frequently hop between IPv4 and IPv6 networks — for
+example Wi-Fi (often IPv4) to cellular (often IPv6), or a corporate
+VPN dropping and leaving only the native connection. When the address
+family of the active interface changes, several things can break:
+
+- **Existing dialogs still reference the old family.** The Contact and
+  Via URIs in an established call contain the old address; once the
+  interface goes away, the remote has no way to reach the endpoint.
+- **SIP transports bound to the old family are unusable.** A
+  UDP6/TCP6/TLS6 transport bound to a now-gone IPv6 address cannot
+  send, and the registrar's re-registration attempts time out.
+- **Media (RTP/RTCP) is pointed at the old address.** Even if
+  signalling survives, media won't flow without a new offer/answer.
+- **If ICE wasn't enabled**, there is no pre-gathered alternative
+  candidate to fall back to — the call typically has to be dropped.
+
+**Mechanism.** Call :cpp:any:`pjsua_handle_ip_change()` when the OS
+reports a network change. It re-resolves, re-creates transports if
+needed, re-registers, and issues re-INVITEs on active calls so media
+addresses are updated. :pr:`3910` improved the v4↔v6 path so the
+transition works when the address family flips. :pr:`4067` further
+refined the IP-version selection in the re-generated SDP offer so it
+matches the account's ``ipv6_media_use`` mode after the transport is
+re-created. See the dedicated :doc:`IP address change guide
+<ip_change>` for the full mechanism.
+
+**Design guidance.** To make these transitions survivable:
+
+- **Configure the account for the union of address families you expect
+  to see.** An endpoint that might move to an IPv6-only cellular leg
+  should not be ``ipv6_sip_use = DISABLED``; use
+  ``ENABLED_NO_PREFERENCE`` or ``ENABLED_PREFER_IPV6`` so PJSIP can
+  actually pick the new family after the hand-off.
+- **Enable ICE for media** (see best practices above) so both families'
+  candidates are already gathered at call setup; re-INVITEs after an
+  IP change can then nominate a new candidate pair without a full
+  media renegotiation stall.
+- **Use DNS names for the registrar and proxy.** After the
+  hand-off, re-resolution picks whichever family works from the new
+  interface; an IP literal may be unreachable from the new network.
+
+
+.. _ipv6_nat64:
 
 NAT64
 -----
@@ -251,35 +436,51 @@ Therefore, to support IPv6-IPv4 interoperability in NAT64 environment:
 #. Our RECOMMENDATION is that when the client is put with an IPv6-only connectivity, the SIP server must also support IPv6  connectivity. For  the media, user needs a "dual stack" TURN (a TURN server which supports IPv6 connectivity and able to provide an IPv4 relay address upon request). Then all the application needs to do is enable ICE and use TURN (support for dual stack TURN is only available in PJSIP 2.6 or later). 
 #. If 1) is not possible (no IPv6 server or not desirable to use TURN), we will need to replace all IPv6 occurences with IPv4 in the SIP messages and SDP. This feature is available in release 2.7.
 
-   a. You need a STUN server which resides in an IPv4 network. Then set your :cpp:any:`pjsua_config` to try IPv6 resolution of the STUN servers. 
-   b. Create UDP6 transport to get an IPv4-mapped address from the above STUN server. 
-   c. Bind account to a specific IPv6 transport, and enable IPv6 in media transport. 
-   d. Set account's NAT64 option to PJSUA_NAT64_ENABLED. 
-   
+   a. Set :cpp:any:`pjsua_config::stun_try_ipv6` so PJSIP will resolve
+      the STUN server(s) via AAAA as well as A.
+   b. Create a UDP6 transport; the STUN server on the IPv4 network will
+      hand back an IPv4-mapped address through the NAT64 translator.
+   c. Configure the account as IPv6-only for both signalling and media,
+      and enable NAT64.
+
+   PJSIP 2.14+ (PJSUA-LIB):
+
    .. code-block:: c
 
         cfg->stun_try_ipv6 = PJ_TRUE;
 
-        tp_type = PJSIP_TRANSPORT_UDP6; 
+        tp_type = PJSIP_TRANSPORT_UDP6;
         status = pjsua_transport_create(tp_type, &tp_cfg, &udp6_tp_id);
 
-        // For PJSIP 2.14 and above
-        acc_cfg.ipv6_sip_use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.ipv6_sip_use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
         acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.nat64_opt      = PJSUA_NAT64_ENABLED;
 
-        // For PJSIP earlier than 2.14
-        // acc_cfg.transport_id = udp6_tp_id; // or tcp6_tp_id or tls6_tp_id
-        // acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED;
+   PJSIP 2.14+ (PJSUA2):
 
-        acc_cfg.nat64_opt = PJSUA_NAT64_ENABLED;
+   .. code-block:: c++
+
+        ep_cfg.uaConfig.stunTryIpv6 = true;
+
+        acc_cfg.sipConfig.ipv6Use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.mediaConfig.ipv6Use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.natConfig.nat64Opt  = PJSUA_NAT64_ENABLED;
+
+   For PJSIP < 2.14, replace the ``ipv6_*_use`` fields with an
+   explicit ``acc_cfg.transport_id = udp6_tp_id`` binding and
+   ``acc_cfg.ipv6_media_use = PJSUA_IPV6_ENABLED``.
 
 
 References
 ------------
 
+* Dual-stack IPv4&IPv6 account config (PJSIP 2.14): :pr:`3590`
+* Improve IP address change IPv4 ↔ IPv6 (PJSIP 2.15): :pr:`3910`
+* Update IP version choosing logic in media transport for SDP offer
+  (PJSIP 2.15): :pr:`4067`
 * Enable IPv6 in ICE transport/TURN in PJSUA: :pr:`1971`
 * NAT64 support for IPv4 interoperability: :pr:`2032`
-* IPv6 support in PJNATH: :pr:`422`
+* IPv6 support in PJNATH: :issue:`422`
 * Address resolution: :pr:`1926`
 * DNS SRV resolution: :pr:`1927`
 

--- a/docs/source/specific-guides/network_nat/ipv6.rst
+++ b/docs/source/specific-guides/network_nat/ipv6.rst
@@ -149,9 +149,10 @@ and media usually traverse different paths:
   endpoint talks to (typically dual-stack).
 
 Because of this split, it is common and valid to have, for example,
-IPv6-only signalling (``USE_IPV6_ONLY``) to a cloud SIP provider while
-media stays dual-stack (``PREFER_IPV4`` or ``PREFER_IPV6``) so calls
-to legacy IPv4 peers still work.
+IPv6-only signalling (``PJSUA_IPV6_ENABLED_USE_IPV6_ONLY``) to a cloud
+SIP provider while media stays dual-stack
+(``PJSUA_IPV6_ENABLED_PREFER_IPV4`` or ``PJSUA_IPV6_ENABLED_PREFER_IPV6``)
+so calls to legacy IPv4 peers still work.
 
 The :cpp:any:`pjsua_ipv6_use` enum values:
 
@@ -177,6 +178,13 @@ The :cpp:any:`pjsua_ipv6_use` enum values:
    * - ``PJSUA_IPV6_ENABLED_USE_IPV6_ONLY``
      - IPv6 only; IPv4 addresses/candidates are not used. Required for
        NAT64-only networks.
+
+.. note::
+
+   For brevity the rest of this page refers to each value by its
+   suffix, e.g. ``USE_IPV6_ONLY`` for
+   ``PJSUA_IPV6_ENABLED_USE_IPV6_ONLY`` and ``DISABLED`` for
+   ``PJSUA_IPV6_DISABLED``. Use the full identifier names in code.
 
 Preference only applies to the **outgoing** direction. For incoming
 messages or offers, PJSIP accepts whichever IP version the remote
@@ -434,7 +442,7 @@ According to :rfc:`6157` (IPv6 Transition in the Session Initiation Protocol (SI
 Therefore, to support IPv6-IPv4 interoperability in NAT64 environment:
 
 #. Our RECOMMENDATION is that when the client is put with an IPv6-only connectivity, the SIP server must also support IPv6  connectivity. For  the media, user needs a "dual stack" TURN (a TURN server which supports IPv6 connectivity and able to provide an IPv4 relay address upon request). Then all the application needs to do is enable ICE and use TURN (support for dual stack TURN is only available in PJSIP 2.6 or later). 
-#. If 1) is not possible (no IPv6 server or not desirable to use TURN), we will need to replace all IPv6 occurences with IPv4 in the SIP messages and SDP. This feature is available in release 2.7.
+#. If 1) is not possible (no IPv6 server or not desirable to use TURN), we will need to replace all IPv6 occurrences with IPv4 in the SIP messages and SDP. This feature is available in release 2.7.
 
    a. Set :cpp:any:`pjsua_config::stun_try_ipv6` so PJSIP will resolve
       the STUN server(s) via AAAA as well as A.


### PR DESCRIPTION
## Summary

Revise the IPv6/NAT64 and IP-change guides to reflect PJSIP 2.14+ configuration and add missing PJSUA2 coverage. Fixes several accuracy issues noticed while reviewing.

## Changes — `ipv6.rst`

- **Availability** — drop Symbian/XP/Server 2003 mentions; drop the "./configure"-only framing. Note that both autotools and CMake auto-detect the host's IPv6 socket capabilities (`getaddrinfo`, `IPV6_V6ONLY`), while `PJ_HAS_IPV6` remains an explicit opt-in via `config_site.h`.
- **Per-layer sections** (pjlib / pjsip / pjlib-util / pjmedia / pjnath) — rewrite the "has been added / now / has been updated" phrasing into present tense. Fix:
  - "IPv6 Support in pjsip" header incorrectly said the pjsip ticket documents work in *pjlib*
  - Bare `#420` / `#422` replaced with proper `:issue:` extlinks
  - `pj_ice_strans_turn_cfg_default()` (was a copy-paste of `stun_cfg_default`)
- **New: IPv6 Modes and Defaults (PJSIP 2.14+)** — the central reference readers were missing:
  - Table of the five `pjsua_ipv6_use` values with meaning
  - Rationale for why `sip`/`media` preferences are independent (endpoint↔server vs peer-to-peer paths), with a concrete mixed-mode example
  - Incoming-direction caveats (`DISABLED` excludes IPv6 in both directions, `USE_IPV6_ONLY` excludes IPv4, dual-stack modes accept either)
  - Mode-choice decision guide
  - Best-practices for dual-stack (hostnames not literals, ICE for media, dual-stack TURN, plan for IP changes)
- **SIP Account subsection rewritten** — 2.14+ primary example (C + PJSUA2); pre-2.14 binding example demoted to a fallback block.
- **New: IPv4 ↔ IPv6 transitions during IP address change** — what breaks (old-family dialogs, bound transports, media addresses, missing ICE candidates), mechanism (`pjsua_handle_ip_change` + #3910 + #4067), design guidance. Links to the dedicated `ip_change` guide.
- **NAT64** — code blocks modernized to 2.14+ (C + PJSUA2), pre-2.14 as a fallback note.
- **References** — added #3590 (2.14), #3910 (2.15), #4067 (2.15).
- New anchors `_ipv6_modes:` and `_ipv6_ip_change:` for cross-linking.

## Changes — `ip_change.rst`

- Fix "the the" typo in the transport-listener-restart bullet.
- Fix `pjsua_callback::PJSUA_CALL_UPDATE_CONTACT` → `PJSUA_CALL_UPDATE_CONTACT` (the enum value lives in `pjsua_call_flag`, not `pjsua_callback`).
- Remove the duplicate "Update Contact" bullet (and the stray `:flag)` typo inside the removed copy). The intro says "two steps" — the list now has two.
- Replace the Trac-era `[wiki:ipv6 here]` with proper `:doc:` + `:ref:` links into the new `ipv6_modes` anchor.
- Extract the `PREFER_IPV6` gotcha out of an in-code comment into a prose `.. note::` explaining *why* existing calls stay on the old family (negotiated media state is immutable; preference only affects future offers) and when to use `USE_IPV6_ONLY` instead.
- Add a PJSUA2 equivalent of `ip_change_to_ip6()` using `Endpoint::handleIpChange` / `Account::modify` / `regConfig.disableRegOnModify`, with a note that `AccountConfig` has no getter so the app must keep its own copy.

## Test plan

- [x] `sphinx-build -b html` completes without new warnings
- [x] All `:pr:` / `:issue:` extlinks resolve in rendered HTML
- [x] Cross-links work both directions (`ipv6.html#ipv6-modes` from `ip_change.html`, and `ip_change.html#…` from `ipv6.html`)
- [x] PJSUA2 API references verified against `pjsip/include/pjsua2/{endpoint,account}.hpp`
- [x] Release-tag claims in References verified via `git tag --contains` (#3910 and #4067 both in 2.15)

Co-Authored-By: Claude Code
