### PR TITLE
Fill PJSUA2 video walkthrough gaps + clarify iOS codec requirement

### DIFF
--- a/docs/source/get-started/ios/build_instructions.rst
+++ b/docs/source/get-started/ios/build_instructions.rst
@@ -204,30 +204,41 @@ Some of the highlighted features include:
 Requirements
 ^^^^^^^^^^^^
 
+.. important::
+
+   On iOS, no video codec is enabled by default. A video build that
+   defines only ``PJMEDIA_HAS_VIDEO 1`` will compile but **no video call
+   can be negotiated**, because the SDP carries no offered codec. You
+   must enable at least one of the codec backends below — H.264 via
+   VideoToolbox or OpenH264, and/or VP8/VP9 via libvpx.
+
 libyuv
 ``````
 
-#. If you are using 2.5.5 or newer, libyuv should be built and enabled 
+#. If you are using 2.5.5 or newer, libyuv should be built and enabled
    automatically, see :pr:`1937` for more info.
 #. If you are using 2.5.1 or older, follow the instructions in :pr:`1776`.
 
 .. _videotoolbox:
 
-OpenH264 or **VideoToolbox** (if you need H264 codec, choose one of them)
-``````````````````````````````````````````````````````````````````````````
+H.264 — VideoToolbox or OpenH264
+````````````````````````````````
 
-* For OpenH264, see :ref:`openh264`
-* For **VideoToolbox** (supported since PJSIP version 2.7), define this in 
-  your ``config_site.h``:
+H.264 is the de-facto SIP video codec. Pick one of:
+
+* **VideoToolbox** (Apple hardware codec, supported since PJSIP 2.7).
+  Define this in your ``config_site.h``:
 
   .. code-block:: c
 
      #define PJMEDIA_HAS_VID_TOOLBOX_CODEC 1
 
-libvpx (if you need VP8 or VP9 codec)
-`````````````````````````````````````
+* **OpenH264** (software codec from Cisco). See :ref:`openh264`.
 
-See See :ref:`libvpx`
+libvpx — VP8 / VP9
+``````````````````
+
+For VP8 or VP9, see :ref:`libvpx`.
 
 Configuring
 ^^^^^^^^^^^^
@@ -253,6 +264,9 @@ Set these in your :ref:`config_site.h`:
 
    #define PJ_CONFIG_IPHONE 			1
    #define PJMEDIA_HAS_VIDEO			1
+
+   /* Enable at least one video codec — see Requirements above. */
+   #define PJMEDIA_HAS_VID_TOOLBOX_CODEC	1
 
    #include <pj/config_site_sample.h>
 

--- a/docs/source/get-started/ios/build_instructions.rst
+++ b/docs/source/get-started/ios/build_instructions.rst
@@ -224,7 +224,7 @@ libyuv
 H.264 — VideoToolbox or OpenH264
 ````````````````````````````````
 
-H.264 is the de-facto SIP video codec. Pick one of:
+H.264 is the de facto SIP video codec. Pick one of:
 
 * **VideoToolbox** (Apple hardware codec, supported since PJSIP 2.7).
   Define this in your ``config_site.h``:
@@ -265,7 +265,9 @@ Set these in your :ref:`config_site.h`:
    #define PJ_CONFIG_IPHONE 			1
    #define PJMEDIA_HAS_VIDEO			1
 
-   /* Enable at least one video codec — see Requirements above. */
+   /* Enable at least one video codec — see Requirements above.
+      VideoToolbox requires PJSIP 2.7+; on older versions enable
+      OpenH264 (PJMEDIA_HAS_OPENH264_CODEC) instead. */
    #define PJMEDIA_HAS_VID_TOOLBOX_CODEC	1
 
    #include <pj/config_site_sample.h>

--- a/docs/source/pjsua2/using/media_video.rst
+++ b/docs/source/pjsua2/using/media_video.rst
@@ -284,10 +284,11 @@ stream(s) via :cpp:func:`pj::Call::vidSetStream()`. Common operations:
       } catch(Error& err) {
       }
 
-Other operations include ``PJSUA_CALL_VID_STRM_ADD`` and ``REMOVE`` to add
-or remove a video stream from an established call, and
-``PJSUA_CALL_VID_STRM_SEND_KEYFRAME`` to force a keyframe on the next
-encoded frame. See :cpp:any:`pjsua_call_vid_strm_op` for the full list.
+Other operations include ``PJSUA_CALL_VID_STRM_ADD`` and
+``PJSUA_CALL_VID_STRM_REMOVE`` to add or remove a video stream from an
+established call, and ``PJSUA_CALL_VID_STRM_SEND_KEYFRAME`` to force a
+keyframe on the next encoded frame. See :cpp:any:`pjsua_call_vid_strm_op`
+for the full list.
 
 
 Configuring a video window

--- a/docs/source/pjsua2/using/media_video.rst
+++ b/docs/source/pjsua2/using/media_video.rst
@@ -29,6 +29,9 @@ Working with video media
    renderer / codec / format-converter backends per platform and the
    PJMEDIA event types a video application typically subscribes to.
 
+   For sample applications that exercise video, see
+   :any:`Sample Applications with Video <vid_ug_samples>`.
+
 
 Video media is similar to audio media in many ways. The class :cpp:class:`pj::VideoMedia` is
 also derived from :cpp:class:`pj::Media` class. Its object types also consist of capture &
@@ -71,6 +74,36 @@ can start/stop the transmission to a destination by using the API
 
     In the video conference bridge, the port zero is not special like in audio, which is designated
     for the main audio device. In video, port zero can be assigned to any type of video object.
+
+
+Account video configuration
+----------------------------
+Video defaults for an account live in :cpp:class:`pj::AccountVideoConfig`,
+exposed as ``AccountConfig::videoConfig``. The most commonly-used fields:
+
+- ``autoTransmitOutgoing`` — when ``true``, the account starts sending
+  video for outgoing calls automatically. Default ``false``.
+- ``autoShowIncoming`` — when ``true``, the renderer window for incoming
+  video is shown automatically. Default ``false``.
+- ``defaultCaptureDevice`` and ``defaultRenderDevice`` — capture and
+  renderer device IDs used when starting a video call. Default to the
+  platform default capture / renderer.
+- ``windowFlags`` — bitmask of ``PJMEDIA_VID_DEV_WND_*`` flags applied to
+  newly-created renderer windows.
+
+.. code-block:: c++
+
+    AccountConfig acc_cfg;
+    // ... other configuration ...
+    acc_cfg.videoConfig.autoTransmitOutgoing = true;
+    acc_cfg.videoConfig.autoShowIncoming     = true;
+    acc_cfg.videoConfig.defaultCaptureDevice = PJMEDIA_VID_DEFAULT_CAPTURE_DEV;
+    acc_cfg.videoConfig.defaultRenderDevice  = PJMEDIA_VID_DEFAULT_RENDER_DEV;
+
+    MyAccount *acc = new MyAccount;
+    acc->create(acc_cfg);
+
+See :cpp:class:`pj::AccountVideoConfig` for the full set of fields.
 
 
 Starting camera preview
@@ -211,6 +244,50 @@ to a renderer video window once the call's video media is started.
     call media. And if there are two or more concurrent video calls sharing the same
     capture device, the device will be transmitting to three or more destinations.
     Thanks to the video conference bridge for its duplicating feature.
+
+
+Modifying video during a call
+------------------------------
+After a call is established, the application can change the active video
+stream(s) via :cpp:func:`pj::Call::vidSetStream()`. Common operations:
+
+- Stop sending video while still receiving:
+
+  .. code-block:: c++
+
+      try {
+          CallVidSetStreamParam param;
+          param.dir = PJMEDIA_DIR_DECODING;
+          call.vidSetStream(PJSUA_CALL_VID_STRM_CHANGE_DIR, param);
+      } catch(Error& err) {
+      }
+
+- Resume sending video:
+
+  .. code-block:: c++
+
+      try {
+          CallVidSetStreamParam param;
+          param.dir = PJMEDIA_DIR_ENCODING_DECODING;
+          call.vidSetStream(PJSUA_CALL_VID_STRM_CHANGE_DIR, param);
+      } catch(Error& err) {
+      }
+
+- Switch capture device (e.g. front camera ↔ rear camera on mobile):
+
+  .. code-block:: c++
+
+      try {
+          CallVidSetStreamParam param;
+          param.capDev = new_cap_dev_id;
+          call.vidSetStream(PJSUA_CALL_VID_STRM_CHANGE_CAP_DEV, param);
+      } catch(Error& err) {
+      }
+
+Other operations include ``PJSUA_CALL_VID_STRM_ADD`` and ``REMOVE`` to add
+or remove a video stream from an established call, and
+``PJSUA_CALL_VID_STRM_SEND_KEYFRAME`` to force a keyframe on the next
+encoded frame. See :cpp:any:`pjsua_call_vid_strm_op` for the full list.
 
 
 Configuring a video window


### PR DESCRIPTION
## Summary

Fills three small gaps in the PJSUA2 video walkthrough and corrects an iOS build-instructions wording that has bitten customers in the field.

## What's new

**`pjsua2/using/media_video.rst` — 3 additions** (matching existing style — `try`/`catch` examples, simple section headers, sparing tip/note blocks):

- **Account video configuration** — `AccountVideoConfig::autoTransmitOutgoing`, `autoShowIncoming`, `defaultCaptureDevice`, `defaultRenderDevice`. Placed before "Starting camera preview" so readers see per-account defaults early.
- **Modifying video during a call** — `Call::vidSetStream()` with worked examples for stop-sending / resume-sending / switching capture device (front ↔ rear camera). Placed after "Call's video media".
- **Sample-apps pointer** — one-line addition to the existing tip block referencing `vid_ug_samples`.

**`get-started/ios/build_instructions.rst` — codec wording fix:**

The previous wording presented OpenH264 / VideoToolbox / libvpx as optional ("if you need H264 codec, choose one of them"). In practice no video codec is enabled by default on iOS — a build with only `PJMEDIA_HAS_VIDEO=1` compiles fine but cannot negotiate any video call because the SDP carries no offered codec. Customers have hit this. Changes:

- New `.. important::` block at the top of the iOS *Video Support → Requirements* section stating explicitly that at least one codec must be enabled.
- Drop "if you need" framing from codec subsection titles.
- Add `PJMEDIA_HAS_VID_TOOLBOX_CODEC=1` alongside `PJMEDIA_HAS_VIDEO=1` in the `config_site.h` example with a comment pointing back to *Requirements*, so a copy-pasted snippet yields a working build by default.

Android equivalent (`get-started/android/build_instructions.rst`) does not have the same problem — it ships `PJMEDIA_HAS_VIDEO=1` and relies on auto-enabled `AMediaCodec` backends for API 28+, which the page already calls out. No Android change needed.

## Test plan

- [x] Local Sphinx build is clean on the touched files (the 180 pre-existing warnings on the branch are all auto-generated `api/generated/*` Breathe noise and one unrelated SRTP cross-ref — none caused by this PR).

Co-Authored-By: Claude Code
