### PR TITLE
Convert video deep-dives to PJSUA2-first with PJSUA-LIB equivalents footer

### DIFF
--- a/docs/source/specific-guides/video/av_sync.rst
+++ b/docs/source/specific-guides/video/av_sync.rst
@@ -3,6 +3,13 @@
 Audio/Video Synchronization
 ============================
 
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page. The page is mostly PJMEDIA-level content
+   (:cpp:any:`pjmedia_av_sync`), which is the same regardless of which
+   higher-level API you use.
+
 When a session carries audio and video together, the two streams
 travel and decode through independent pipelines (jitter buffer,
 decoder, renderer, file demuxer, …) and accumulate independent
@@ -51,22 +58,9 @@ Opting out per call
 
 To disable inter-media synchronization on a specific call, set the
 :cpp:any:`PJSUA_CALL_NO_MEDIA_SYNC` flag (value ``256`` in
-:cpp:any:`pjsua_call_flag`) in :cpp:any:`pjsua_call_setting::flag`.
-PJSUA-LIB will skip synchronizer creation, or destroy an existing one
-if the flag is set on a re-INVITE/UPDATE.
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   pjsua_call_setting opt;
-
-   pjsua_call_setting_default(&opt);
-   opt.flag |= PJSUA_CALL_NO_MEDIA_SYNC;
-
-   pjsua_call_make_call(acc_id, &dst, &opt, NULL, NULL, &call_id);
-
-**PJSUA2 (C++):**
+:cpp:any:`pjsua_call_flag`) in ``CallSetting::flag``. PJSUA-LIB will
+skip synchronizer creation, or destroy an existing one if the flag is
+set on a re-INVITE/UPDATE.
 
 .. code-block:: c++
 
@@ -176,3 +170,19 @@ the synchronizer themselves. The lifecycle:
 :cpp:any:`pjmedia_av_sync_reset()` clears the running per-media state
 without removing the registered media — useful on a re-INVITE/UPDATE
 that significantly changes the topology, or on a file rewind.
+
+
+PJSUA-LIB equivalents
+---------------------
+
+Most of this page is PJMEDIA-level (``pjmedia_av_sync_*``) and applies
+to both APIs unchanged. The only PJSUA2-specific symbols above are:
+
++------------------------------------------------------+------------------------------------------------------+
+| PJSUA2                                               | PJSUA-LIB                                            |
++======================================================+======================================================+
+| ``CallOpParam::opt`` (``CallSetting``) — ``.flag``   | :cpp:any:`pjsua_call_setting::flag` initialised via  |
+|                                                      | :cpp:any:`pjsua_call_setting_default()`              |
++------------------------------------------------------+------------------------------------------------------+
+| :cpp:func:`pj::Call::makeCall()`                     | :cpp:any:`pjsua_call_make_call()`                    |
++------------------------------------------------------+------------------------------------------------------+

--- a/docs/source/specific-guides/video/codec_params.rst
+++ b/docs/source/specific-guides/video/codec_params.rst
@@ -1,30 +1,16 @@
 Modifying Video Codec Parameters
 =================================
 
-Video codec parameters are specified in
-:cpp:any:`pjmedia_vid_codec_param` (PJSUA-LIB) or
-:cpp:any:`pj::VidCodecParam` (PJSUA2). Both expose separate settings for
-the encoding and decoding directions. Read with
-:cpp:any:`pjsua_vid_codec_get_param()` /
-:cpp:func:`pj::Endpoint::getVideoCodecParam()`, modify, and write back
-with :cpp:any:`pjsua_vid_codec_set_param()` /
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
+Video codec parameters are exposed by :cpp:any:`pj::VidCodecParam`,
+which carries separate settings for the encoding and decoding
+directions. Read with :cpp:func:`pj::Endpoint::getVideoCodecParam()`,
+modify, and write back with
 :cpp:func:`pj::Endpoint::setVideoCodecParam()`.
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   const pj_str_t codec_id = {"H264", 4};
-   pjmedia_vid_codec_param param;
-
-   pjsua_vid_codec_get_param(&codec_id, &param);
-
-   /* Modify param here */
-   ...
-
-   pjsua_vid_codec_set_param(&codec_id, &param);
-
-**PJSUA2 (C++):**
 
 .. code-block:: c++
 
@@ -35,32 +21,19 @@ with :cpp:any:`pjsua_vid_codec_set_param()` /
 
    Endpoint::instance().setVideoCodecParam("H264", param);
 
-The PJSUA-LIB struct uses ``param.enc_fmt.det.vid.size.{w,h}``,
-``fps.{num,denum}``, ``avg_bps``, and ``max_bps``; the equivalent
-PJSUA2 fields on :cpp:any:`pj::VidCodecParam::encFmt` (which is a
-:cpp:any:`pj::MediaFormatVideo`) are ``width``, ``height``, ``fpsNum``,
-``fpsDenum``, ``avgBps``, ``maxBps``. The same names apply on the
-``decFmt`` side. The fmtp parameter list (``dec_fmtp`` /
-``decFmtp``) has the same shape in both APIs.
+The relevant ``VidCodecParam`` fields used below are
+:cpp:any:`pj::VidCodecParam::encFmt` (a :cpp:any:`pj::MediaFormatVideo`,
+with ``width`` / ``height`` / ``fpsNum`` / ``fpsDenum`` / ``avgBps`` /
+``maxBps``), the same fields on ``decFmt``, and the fmtp lists
+``encFmtp`` / ``decFmtp`` (each a vector of ``{name, val}`` strings).
 
 
 Size or resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Specify video picture dimension.
+~~~~~~~~~~~~~~~~~~
 
-a. For the encoding direction, configure the size field of
-   :cpp:any:`pjmedia_vid_codec_param::enc_fmt` (PJSUA-LIB) or
-   :cpp:any:`pj::VidCodecParam::encFmt` (PJSUA2):
+Specify the video picture dimension.
 
-   **PJSUA-LIB (C):**
-
-   .. code-block:: c
-
-      /* Sending 1280 x 720 */
-      param.enc_fmt.det.vid.size.w = 1280;
-      param.enc_fmt.det.vid.size.h = 720;
-
-   **PJSUA2 (C++):**
+a. For the encoding direction, configure ``encFmt``:
 
    .. code-block:: c++
 
@@ -71,13 +44,26 @@ a. For the encoding direction, configure the size field of
    .. note::
 
        - Both width and height must be even numbers.
-       - There is a possibility that the value will be adjusted to follow remote capability. For example, if remote signals  that maximum resolution supported is 640 x 480 and locally the encoding direction size is set to 1280 x 720, then 640 x 480 will be used.
-       -  The library will find the closest size/ratio that the capture device supports. Application should choose the size ratio that the capture device supports, otherwise the video might get stretched. For example, if the device capture supports 640x480 and 1280x720 and the size is set to 500x500. The device camera will be opened at 640x480 and later converted to 500x500 and get the image stretched.
+       - The value may be adjusted to follow remote capability — for
+         example, if the peer signals a maximum of 640 × 480 but you
+         set 1280 × 720 locally, the negotiated size will be 640 × 480.
+       - The library finds the closest size/ratio that the capture
+         device supports. Choose a size ratio the device supports;
+         otherwise the video may get stretched. For example, if the
+         device supports 640 × 480 and 1280 × 720 and you set 500 × 500,
+         the camera opens at 640 × 480 and is later stretched to
+         500 × 500.
 
-b. For decoding direction, the following steps are needed:
+b. For the decoding direction:
 
-   1. The ``det.vid.size`` field of :cpp:any:`pjmedia_vid_codec_param::dec_fmt` should be set to the highest value expected for incoming video size.
-   2. If the resolution exceeds the supported maximum specified in the video codecs, you need to modify it (``MAX_RX_WIDTH`` and ``MAX_RX_HEIGHT`` in ``openh264.cpp``, ``vid_toolbox.m``, or ``and_vid_mediacodec.cpp``, or ``MAX_RX_RES`` in ``vpx.c`` or ``ffmpeg_vid_codecs.c``). Defaults at the time of writing:
+   1. Set ``decFmt.width`` / ``decFmt.height`` to the highest values
+      expected for incoming video.
+   2. If the resolution exceeds the supported maximum compiled into
+      the codec backend, you need to bump the per-codec macro
+      (``MAX_RX_WIDTH`` / ``MAX_RX_HEIGHT`` in ``openh264.cpp``,
+      ``vid_toolbox.m``, or ``and_vid_mediacodec.cpp``; ``MAX_RX_RES``
+      in ``vpx.c`` or ``ffmpeg_vid_codecs.c``). Defaults at the time of
+      writing:
 
       +---------------------------+-------------------------+----------------+
       | Codec source              | Macro                   | Default        |
@@ -96,156 +82,167 @@ b. For decoding direction, the following steps are needed:
       | ``ffmpeg_vid_codecs.c``   | ``MAX_RX_RES``          | 1200 (max dim) |
       +---------------------------+-------------------------+----------------+
 
-      Verify in the source if you need to push beyond these — the values may have been updated since.
-   3. signalling to remote, configured via codec specific SDP format parameter (fmtp): :cpp:any:`pjmedia_vid_codec_param::dec_fmtp`.
+      Verify in the source if you need to push beyond these — the
+      values may have been updated since.
 
-       - H263-1998, e.g:
+   3. Signal to the remote side via codec-specific SDP fmtp parameters
+      on ``decFmtp``:
 
-         .. code-block:: c
+      - **H.263-1998:**
 
-            /* 1st preference: 352 x 288 (CIF) */
-            param.dec_fmtp.param[n].name = pj_str("CIF");
-            /* The value actually specifies framerate, see framerate section below */
-            param.dec_fmtp.param[n].val = pj_str("1");
-            /* 2nd preference: 176 x 144 (QCIF) */
-            param.dec_fmtp.param[n+1].name = pj_str("QCIF");
-            /* The value actually specifies framerate, see framerate section below */
-            param.dec_fmtp.param[n+1].val = pj_str("1");
+        .. code-block:: c++
 
-       - H264, the size is implicitly specified in H264 level (check the standard specification or `this Wikipedia page <http://en.wikipedia.org/wiki/H.264/MPEG-4_AVC#Levels>`__) and on SDP, the H264 level is signalled via H264 SDP fmtp `profile-level-id <http://tools.ietf.org/html/rfc6184#section-8.1>`__, e.g:
+           // 1st preference: 352 × 288 (CIF)
+           param.decFmtp.push_back({"CIF",  "1"});
+           // 2nd preference: 176 × 144 (QCIF)
+           param.decFmtp.push_back({"QCIF", "1"});
 
-         .. code-block:: c
+        The fmtp value is the framerate divisor — see *Framerate*
+        below.
 
-            /* Can receive up to 1280×720 @30fps */
-            param.dec_fmtp.param[n].name = pj_str("profile-level-id");
-            /* Set the profile level to "1f", which means level 3.1 */
-            param.dec_fmtp.param[n].val = pj_str("xxxx1f");
+      - **H.264:** size is implicitly specified in the H.264 *level*
+        (see the standard or the
+        `H.264/MPEG-4 AVC levels table
+        <http://en.wikipedia.org/wiki/H.264/MPEG-4_AVC#Levels>`__),
+        signalled via the H.264 SDP fmtp
+        `profile-level-id
+        <http://tools.ietf.org/html/rfc6184#section-8.1>`__:
+
+        .. code-block:: c++
+
+           // Can receive up to 1280 × 720 @ 30 fps
+           // Set the profile level to "1f", which means level 3.1
+           param.decFmtp.push_back({"profile-level-id", "xxxx1f"});
+
 
 Framerate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Specify number of frames processed per second.
+~~~~~~~~~
 
-a. For the encoding direction, configure the fps field of
-   :cpp:any:`pjmedia_vid_codec_param::enc_fmt` (PJSUA-LIB) or
-   :cpp:any:`pj::VidCodecParam::encFmt` (PJSUA2):
+Specify the number of frames processed per second.
 
-   **PJSUA-LIB (C):**
-
-   .. code-block:: c
-
-      /* Sending @30fps */
-      param.enc_fmt.det.vid.fps.num   = 30;
-      param.enc_fmt.det.vid.fps.denum = 1;
-
-   **PJSUA2 (C++):**
+a. For the encoding direction, configure ``encFmt``:
 
    .. code-block:: c++
 
-      // Sending @30fps
+      // Sending @ 30 fps
       param.encFmt.fpsNum   = 30;
       param.encFmt.fpsDenum = 1;
 
    .. note::
 
-        - There is a possibility that the value will be adjusted to follow remote capability. For example, if remote signals that maximum framerate supported is 10fps and locally the encoding direction framerate is set to 30fps, then 10fps will be used.
-        - **Limitation:** if preview is enabled before the call is established, the capture device will be opened using the device's default framerate, and subsequent calls that use that device will use this framerate regardless of the configured encoding framerate that is set above. Currently the only workaround is to disable preview before establishing media and re-enable it once the video media is established.
+       - The value may be adjusted to follow remote capability — for
+         example, if the peer signals a maximum of 10 fps but you set
+         30 fps locally, 10 fps will be used.
+       - **Limitation:** if preview is enabled before the call is
+         established, the capture device opens at the device's default
+         framerate, and subsequent calls reusing that device run at
+         that framerate regardless of the encoding framerate set
+         above. The current workaround is to disable preview before
+         media is established and re-enable it once video media is
+         active.
 
-b. For decoding direction, two steps are needed:
+b. For the decoding direction:
 
-   1. The ``det.vid.fps`` of :cpp:any:`pjmedia_vid_codec_param::dec_fmt` should be set to the highest value expected for incoming video framerate.
-   2. signalling to remote, configured via codec specific SDP format parameter (fmtp): :cpp:any:`pjmedia_vid_codec_param::dec_fmtp`.
+   1. Set ``decFmt.fpsNum`` / ``decFmt.fpsDenum`` to the highest
+      values expected for incoming video.
+   2. Signal to the remote side via codec-specific SDP fmtp on
+      ``decFmtp``:
 
-      - H263-1998, maximum framerate is specified per size/resolution basis, check `RFC 4629 Section 8.1.1 <http://tools.ietf.org/html/rfc4629#section-8.1.1>`__ for more info.
+      - **H.263-1998:** maximum framerate is specified per
+        size/resolution. See
+        `RFC 4629 §8.1.1
+        <http://tools.ietf.org/html/rfc4629#section-8.1.1>`__.
 
-         .. code-block:: c
+        .. code-block:: c++
 
-            /* 3000/(1.001*2) fps for CIF */
-            param.dec_fmtp.param[m].name = pj_str("CIF");
-            param.dec_fmtp.param[m].val = pj_str("2");
-            /* 3000/(1.001*1) fps for QCIF */
-            param.dec_fmtp.param[n].name = pj_str("QCIF");
-            param.dec_fmtp.param[n].val = pj_str("1");
+           // 3000 / (1.001 × 2) fps for CIF
+           param.decFmtp.push_back({"CIF",  "2"});
+           // 3000 / (1.001 × 1) fps for QCIF
+           param.decFmtp.push_back({"QCIF", "1"});
 
-      - H264, similar to size/resolution, the framerate is implicitly specified in H264 level (check the standard specification or `MPEG-4 AVC levels <http://en.wikipedia.org/wiki/H.264/MPEG-4_AVC#Levels>`__) and the H264 level is signalled via H264 SDP fmtp ``profile-level-id``, e.g:
+      - **H.264:** like resolution, framerate is implicitly specified
+        in the H.264 *level* and signalled via ``profile-level-id``:
 
-         .. code-block:: c
+        .. code-block:: c++
 
-            /* Can receive up to 1280×720 @30fps */
-            param.dec_fmtp.param[n].name = pj_str("profile-level-id");
-            param.dec_fmtp.param[n].val = pj_str("xxxx1f");
+           // Can receive up to 1280 × 720 @ 30 fps
+           param.decFmtp.push_back({"profile-level-id", "xxxx1f"});
+
 
 Bitrate
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Specify bandwidth requirement for video payloads stream delivery.
+~~~~~~~
 
-This is configurable via ``avg_bps`` and ``max_bps`` on
-:cpp:any:`pjmedia_vid_codec_param::enc_fmt` (PJSUA-LIB) or
-:cpp:any:`pj::VidCodecParam::encFmt` (PJSUA2):
+Specify the bandwidth requirement for the video payload stream.
 
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   /* Bitrate range preferred: 512-1024kbps */
-   param.enc_fmt.det.vid.avg_bps = 512000;
-   param.enc_fmt.det.vid.max_bps = 1024000;
-
-**PJSUA2 (C++):**
+This is configurable via ``avgBps`` and ``maxBps`` on ``encFmt``:
 
 .. code-block:: c++
 
-   // Bitrate range preferred: 512-1024 kbps
+   // Bitrate range preferred: 512 – 1024 kbps
    param.encFmt.avgBps = 512000;
    param.encFmt.maxBps = 1024000;
 
 .. note::
 
-   - This setting is applicable for encoding and decoding direction,
-     currently there is no way to set asymmetric bitrate. By decoding
-     direction, actually it just means that this setting will be queried when
-     generating bandwidth info for local SDP (see next point).
-   - The bitrate
-     setting of all codecs will be enumerated and the highest value will be
-     signalled in bandwidth info in local SDP (see ticket :issue:`1244`).
-   - There is
-     a possibility that the encoding bitrate will be adjusted to follow
-     remote bitrate setting, i.e: read from SDP bandwidth info (b=TIAS line)
-     in remote SDP. For example, if remote signals that maximum bitrate is
-     128kbps and locally the bitrate is set to 512kbps, then 128kbps will be
-     used.
-   - If codec specific bitrate setting signalling (via SDP fmtp) is
-     desired, e.g: *MaxBR* for H263, application should put the SDP fmtp
-     manually, for example:
+   - This setting applies to encoding *and* decoding directions —
+     there is currently no way to set asymmetric bitrate. On the
+     decoding side it is just queried when generating the bandwidth
+     info for the local SDP (next point).
+   - The bitrate setting of all codecs is enumerated and the highest
+     value is signalled in the bandwidth info of the local SDP (see
+     ticket :issue:`1244`).
+   - The negotiated encoding bitrate may be adjusted to follow the
+     remote setting (read from the SDP ``b=TIAS`` line in the remote
+     SDP). For example, if the peer signals a max bitrate of 128 kbps
+     but you set 512 kbps locally, 128 kbps will be used.
+   - For codec-specific bitrate signalling via SDP fmtp (e.g. *MaxBR*
+     for H.263), set the fmtp manually:
 
-     .. code-block:: c
+     .. code-block:: c++
 
-        /* H263 specific maximum bitrate 512kbps */
-        param.dec_fmtp.param[n].name = pj_str("MaxBR");
-        param.dec_fmtp.param[n].val = pj_str("5120"); /* = max_bps / 100 */
+        // H.263 specific maximum bitrate 512 kbps
+        param.decFmtp.push_back({"MaxBR", "5120"});  // = max_bps / 100
 
-The codec's ``avg_bps`` / ``max_bps`` only configure the encoder's
+The codec's ``avgBps`` / ``maxBps`` only configure the encoder's
 target; they do not by themselves shape the actual outgoing packet
-stream. Per-stream send rate control is configured separately via
-:cpp:any:`pjmedia_vid_stream_rc_config`, exposed in PJSUA-LIB as
-:cpp:any:`pjsua_acc_config::vid_stream_rc_cfg`. Two fields:
+stream. Per-stream send rate control is configured separately on the
+account, via two fields on ``AccountVideoConfig``:
 
-- :cpp:any:`pjmedia_vid_stream_rc_config::method` — selects how
-  transmission is paced:
+- ``rateControlMethod`` — selects how transmission is paced. Values
+  come from :cpp:any:`pjmedia_vid_stream_rc_method`:
 
-  - :cpp:any:`PJMEDIA_VID_STREAM_RC_NONE <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_NONE>`:
+  - :cpp:any:`PJMEDIA_VID_STREAM_RC_NONE
+    <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_NONE>`:
     no shaping; RTP packets are sent immediately after encoding.
-  - :cpp:any:`PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING>`:
-    the thread invoking ``put_frame()`` (typically the capture thread)
-    blocks when transmission is ahead of schedule.
-  - :cpp:any:`PJMEDIA_VID_STREAM_RC_SEND_THREAD <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_SEND_THREAD>`
-    (default): a dedicated sending thread queues and paces RTP
-    packets, so the capture thread never blocks. Generally yields
-    better video latency than the blocking method.
+  - :cpp:any:`PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING
+    <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_SIMPLE_BLOCKING>`
+    (PJSUA2 default): the thread invoking ``put_frame()`` (typically
+    the capture thread) blocks when transmission is ahead of schedule.
+  - :cpp:any:`PJMEDIA_VID_STREAM_RC_SEND_THREAD
+    <pjmedia_vid_stream_rc_method::PJMEDIA_VID_STREAM_RC_SEND_THREAD>`
+    (PJMEDIA / PJSUA-LIB default): a dedicated sending thread queues
+    and paces RTP packets, so the capture thread never blocks.
+    Generally yields better video latency than the blocking method.
 
-- :cpp:any:`pjmedia_vid_stream_rc_config::bandwidth` — explicit upstream
-  bandwidth in bps. When ``0`` (default), the rate controller follows
-  the codec's ``max_bps``. Set this if you need stricter shaping than
-  the encoder target.
+  Note the PJSUA2 ``AccountVideoConfig`` constructor initialises
+  ``rateControlMethod`` to ``SIMPLE_BLOCKING``, which differs from
+  the PJSUA-LIB / PJMEDIA default of ``SEND_THREAD``. Set it
+  explicitly if you want ``SEND_THREAD`` from PJSUA2.
+
+- ``rateControlBandwidth`` — explicit upstream bandwidth in bps. When
+  ``0`` (default), the rate controller follows the codec's ``maxBps``.
+  Set this if you need stricter shaping than the encoder target.
+
+.. code-block:: c++
+
+   AccountConfig acc_cfg;
+   // ... other configuration ...
+   acc_cfg.videoConfig.rateControlMethod    = PJMEDIA_VID_STREAM_RC_SEND_THREAD;
+   acc_cfg.videoConfig.rateControlBandwidth = 0;
+
+   MyAccount *acc = new MyAccount;
+   acc->create(acc_cfg);
+
 
 Choosing a bitrate
 ^^^^^^^^^^^^^^^^^^
@@ -301,3 +298,34 @@ imposes), see the
 `H.264/MPEG-4 AVC levels table <https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels>`__.
 For H.263 framerate-per-resolution limits, see
 `RFC 4629 §8.1.1 <https://tools.ietf.org/html/rfc4629#section-8.1.1>`__.
+
+
+PJSUA-LIB equivalents
+---------------------
+
++----------------------------------------------------+--------------------------------------------------------+
+| PJSUA2                                             | PJSUA-LIB                                              |
++====================================================+========================================================+
+| ``VidCodecParam``                                  | :cpp:any:`pjmedia_vid_codec_param`                     |
++----------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::Endpoint::getVideoCodecParam()`     | :cpp:any:`pjsua_vid_codec_get_param()`                 |
++----------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::Endpoint::setVideoCodecParam()`     | :cpp:any:`pjsua_vid_codec_set_param()`                 |
++----------------------------------------------------+--------------------------------------------------------+
+| ``VidCodecParam::encFmt`` /                        | ``pjmedia_vid_codec_param::enc_fmt`` /                 |
+| ``decFmt`` (``MediaFormatVideo``)                  | ``dec_fmt`` (``pjmedia_format``); fields below are     |
+|                                                    | inside ``.det.vid`` (``pjmedia_video_format_detail``). |
++----------------------------------------------------+--------------------------------------------------------+
+| ``MediaFormatVideo::width`` / ``.height``          | ``enc_fmt.det.vid.size.w`` / ``.h``                    |
++----------------------------------------------------+--------------------------------------------------------+
+| ``MediaFormatVideo::fpsNum`` / ``.fpsDenum``       | ``enc_fmt.det.vid.fps.num`` / ``.denum``               |
++----------------------------------------------------+--------------------------------------------------------+
+| ``MediaFormatVideo::avgBps`` / ``.maxBps``         | ``enc_fmt.det.vid.avg_bps`` / ``.max_bps``             |
++----------------------------------------------------+--------------------------------------------------------+
+| ``VidCodecParam::encFmtp`` / ``decFmtp``           | ``pjmedia_vid_codec_param::enc_fmtp`` / ``dec_fmtp``   |
+| (``CodecFmtpVector`` of ``{name, val}``)           | (``pjmedia_codec_fmtp`` with ``param[]`` of            |
+|                                                    | ``{name, val}``)                                       |
++----------------------------------------------------+--------------------------------------------------------+
+| ``AccountVideoConfig::rateControlMethod`` /        | :cpp:any:`pjsua_acc_config::vid_stream_rc_cfg`         |
+| ``rateControlBandwidth``                           | (``pjmedia_vid_stream_rc_config``)                     |
++----------------------------------------------------+--------------------------------------------------------+

--- a/docs/source/specific-guides/video/conference.rst
+++ b/docs/source/specific-guides/video/conference.rst
@@ -3,6 +3,11 @@
 Video Conference
 =================
 
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
 The video conference bridge is the routing fabric that PJMEDIA uses to
 move video frames between sources (capture devices, call decoders,
 file players) and sinks (renderers, call encoders, file writers). It
@@ -10,6 +15,10 @@ plays the same role for video that the audio conference bridge plays
 for audio: every video media object is registered with the bridge as a
 *port* (identified by a slot ID), and the application connects sources
 to sinks to make video flow.
+
+In PJSUA2 each bridge port is wrapped as a :cpp:any:`pj::VideoMedia`
+that knows its slot ID and exposes ``startTransmit()`` /
+``stopTransmit()`` for connecting flows.
 
 Available since PJSIP 2.9. The original design discussion lives in
 ticket :issue:`2181`.
@@ -21,7 +30,9 @@ How the bridge works
 - Each video media object — a call's encoding stream, a call's decoding
   stream, a capture device, a renderer, an AVI player, an arbitrary
   ``pjmedia_port`` — registers as a port in the bridge and is
-  identified by a slot ID of type :cpp:any:`pjsua_conf_port_id`.
+  identified by a slot ID. In PJSUA2 the slot is encapsulated in a
+  ``VideoMedia`` instance; the raw integer ID is available via
+  :cpp:func:`pj::VideoMedia::getPortId()` if needed.
 - Connections are **unidirectional**: a source's frames are copied to
   zero or more sinks. To make video flow both ways between two
   endpoints, the application must establish two separate connections.
@@ -40,9 +51,9 @@ How the bridge works
 Bridge configuration and limits
 -------------------------------
 
-PJSUA-LIB creates a single video conference bridge during initialization
-with default settings (see :cpp:any:`pjmedia_vid_conf_setting`). The
-defaults that matter:
+PJSUA-LIB creates a single video conference bridge during
+initialization with default settings (see
+:cpp:any:`pjmedia_vid_conf_setting`). The defaults that matter:
 
 - **Frame rate**: 60 fps. The bridge runs at one rate and resamples
   port frames to it. For smooth playback, the bridge rate should be a
@@ -50,8 +61,8 @@ defaults that matter:
   ports running at 10, 15, 20, or 30 fps align cleanly; a port at e.g.
   24 fps will jitter against the 60 fps grid. If your application has
   unusual frame-rate combinations, you'd need to raise the bridge rate
-  accordingly — but PJSUA-LIB does not expose a setter for this, so
-  changing it requires either using the lower-level
+  accordingly — but neither PJSUA-LIB nor PJSUA2 exposes a setter for
+  this, so changing it requires either using the lower-level
   :cpp:any:`pjmedia_vid_conf_create()` API directly or modifying
   ``pjsua_vid.c``.
 - **Maximum slot count**: 32. This is the absolute ceiling on the
@@ -126,13 +137,13 @@ The slot order in the layout follows the order in which sources were
 connected to the sink (the ``transmitters`` array in
 :cpp:any:`pjsua_vid_conf_port_info`).
 
-**5 or more sources** — :cpp:any:`pjsua_vid_conf_connect()` does not
-enforce a 4-source limit, so additional connections succeed and the
-sources are tracked in the sink's transmitter list. However, the
-rendering layout switch only handles 1–4, so only the **first 4
-connected sources** are tiled into the sink frame. Frames from sources
-connected beyond the fourth are silently dropped at render time
-without an error — they simply don't appear in the mixed output.
+**5 or more sources** — the connect call does not enforce a 4-source
+limit, so additional connections succeed and the sources are tracked
+in the sink's transmitter list. However, the rendering layout switch
+only handles 1–4, so only the **first 4 connected sources** are tiled
+into the sink frame. Frames from sources connected beyond the fourth
+are silently dropped at render time without an error — they simply
+don't appear in the mixed output.
 
 .. _vid_conf_custom_port:
 
@@ -144,9 +155,11 @@ The bridge's built-in tile mixing covers the common
 behaviour is implemented by inserting a custom intermediate
 ``pjmedia_port`` — application code that consumes incoming frames
 from one or more upstream sources and emits a single composed
-frame for downstream sinks. Register it with
-:cpp:any:`pjsua_vid_conf_add_port()` and connect upstream sources to
-it (and it to the eventual sink) like any other bridge port.
+frame for downstream sinks. In PJSUA2, derive from ``VideoMedia``,
+register the underlying port via
+:cpp:func:`pj::VideoMedia::registerMediaPort2()`, then connect
+upstream sources into it and it into the eventual sink like any other
+``VideoMedia``.
 
 This pattern handles, among others:
 
@@ -179,15 +192,16 @@ encoders, renderers) don't need to know any of this is happening — the
 selection/composition logic stays local to the custom port. If your
 selection state changes mid-call (e.g. a different participant becomes
 the active speaker), update inside the port's ``put_frame`` /
-``get_frame`` implementation; you don't need to call
-:cpp:any:`pjsua_vid_conf_connect()` / ``disconnect()`` on every change.
+``get_frame`` implementation; you don't need to ``startTransmit()`` /
+``stopTransmit()`` on every change.
 
 
 Default wiring
 --------------
 
-When PJSUA-LIB negotiates a video stream on a call, it adds the call's
-encoder and decoder as separate ports and wires them automatically:
+When a video stream is negotiated on a call, the library adds the
+call's encoder and decoder as separate ports and wires them
+automatically:
 
 - The default capture device is connected to the call's encoding slot,
   so the camera reaches the encoder without manual setup.
@@ -207,43 +221,26 @@ The bridge becomes interesting when:
   the call's encoder slot).
 
 
-Looking up slot IDs
--------------------
+Looking up VideoMedia handles
+-----------------------------
 
-Slot IDs are obtained from the library as media objects are created:
+PJSUA2 exposes per-stream VideoMedia objects directly on the call:
 
-- For a call, the per-direction slots are exposed in
-  :cpp:any:`pjsua_call_info`. PJSUA-LIB exposes them as raw slot IDs;
-  PJSUA2 wraps them in :cpp:any:`pj::VideoMedia` objects that already
-  know how to transmit/stop:
+.. code-block:: c++
 
-  **PJSUA-LIB (C):**
+   // Per-stream VideoMedia — each wraps a bridge slot.
+   VideoMedia enc = call.getEncodingVideoMedia(med_idx);
+   VideoMedia dec = call.getDecodingVideoMedia(med_idx);
 
-  .. code-block:: c
+   // The underlying slot IDs, if you need them:
+   int enc_slot = enc.getPortId();
+   int dec_slot = dec.getPortId();
 
-     pjsua_conf_port_id enc, dec;
-
-     enc = pjsua_call_get_vid_conf_port(call_id, PJMEDIA_DIR_ENCODING);
-     dec = pjsua_call_get_vid_conf_port(call_id, PJMEDIA_DIR_DECODING);
-
-  **PJSUA2 (C++):**
-
-  .. code-block:: c++
-
-     // Per-stream VideoMedia objects (each wraps a bridge slot).
-     VideoMedia enc = call.getEncodingVideoMedia(med_idx);
-     VideoMedia dec = call.getDecodingVideoMedia(med_idx);
-
-     // The underlying slot IDs, if you need them:
-     int enc_slot = enc.getPortId();
-     int dec_slot = dec.getPortId();
-
-- For a local capture preview started with
-  :cpp:any:`pjsua_vid_preview_start()`, the slot is returned by
-  :cpp:any:`pjsua_vid_preview_get_vid_conf_port()`.
-- For arbitrary ports added via
-  :cpp:any:`pjsua_vid_conf_add_port()`, the slot is returned through
-  the ``p_id`` out-parameter.
+For a local capture preview started with
+:cpp:func:`pj::VideoPreview::start()`, the corresponding VideoMedia is
+returned by :cpp:func:`pj::VideoPreview::getVideoMedia()`. For
+arbitrary ports added via ``registerMediaPort2()``, the slot is
+available as ``getPortId()`` on the wrapping VideoMedia subclass.
 
 To inspect the bridge as a whole, use
 :cpp:any:`pjsua_vid_conf_get_active_ports()`,
@@ -256,25 +253,15 @@ debugging connection state.
 Connecting and disconnecting flows
 ----------------------------------
 
-The two primitives are:
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   pjsua_vid_conf_connect(source_slot, sink_slot, NULL);
-   pjsua_vid_conf_disconnect(source_slot, sink_slot);
-
-**PJSUA2 (C++):**
+VideoMedia exposes start / stop transmit between any two slots:
 
 .. code-block:: c++
 
-   // VideoMedia exposes startTransmit/stopTransmit between slots.
    source_vm.startTransmit(sink_vm, VideoMediaTransmitParam());
    source_vm.stopTransmit(sink_vm);
 
 Both are unidirectional and both run **asynchronously** — see
-:ref:`async-notification <vid_conf_async>` below.
+:ref:`async notification <vid_conf_async>` below.
 
 
 Three-party video conference
@@ -282,26 +269,6 @@ Three-party video conference
 
 Adding a third leg means cross-connecting two existing calls so their
 remote videos flow to each other in addition to the local participant.
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   pjsua_conf_port_id enc1, dec1, enc2, dec2;
-
-   enc1 = pjsua_call_get_vid_conf_port(call1_id, PJMEDIA_DIR_ENCODING);
-   dec1 = pjsua_call_get_vid_conf_port(call1_id, PJMEDIA_DIR_DECODING);
-   enc2 = pjsua_call_get_vid_conf_port(call2_id, PJMEDIA_DIR_ENCODING);
-   dec2 = pjsua_call_get_vid_conf_port(call2_id, PJMEDIA_DIR_DECODING);
-
-   /* Show call2's video to call1 (and to call1's local renderer if
-    * that connection is also established): */
-   pjsua_vid_conf_connect(dec2, enc1, NULL);
-
-   /* Show call1's video to call2: */
-   pjsua_vid_conf_connect(dec1, enc2, NULL);
-
-**PJSUA2 (C++):**
 
 .. code-block:: c++
 
@@ -321,15 +288,6 @@ that combines the local participant and the other remote.
 
 Tear it down by reversing the connects:
 
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   pjsua_vid_conf_disconnect(dec2, enc1);
-   pjsua_vid_conf_disconnect(dec1, enc2);
-
-**PJSUA2 (C++):**
-
 .. code-block:: c++
 
    dec2.stopTransmit(enc1);
@@ -341,39 +299,36 @@ Adding a custom port
 
 Any ``pjmedia_port`` (for example, the AVI player from
 :cpp:any:`pjmedia_avi_player_create_streams()`) can be registered with
-the bridge so it participates in the routing.
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   pjsua_conf_port_id avi_slot;
-
-   pjsua_vid_conf_add_port(pool, avi_port, NULL, &avi_slot);
-
-   /* Send the AVI video into call1 and also into a local renderer: */
-   pjsua_vid_conf_connect(avi_slot, enc1, NULL);
-   pjsua_vid_conf_connect(avi_slot, my_renderer_slot, NULL);
-
-**PJSUA2 (C++):**
+the bridge so it participates in the routing. PJSUA2's ``VideoMedia``
+exposes the registration helpers as protected, so the application
+derives a wrapper class that calls them and takes ownership of the
+underlying port:
 
 .. code-block:: c++
 
-   // Derive from VideoMedia and register the underlying pjmedia_port
-   // from the AVI player (or any custom port):
-   class MyVideoSource : public VideoMedia {};
+   class CustomVideoPort : public VideoMedia
+   {
+   public:
+       void init(pjmedia_port *port, pj_pool_t *pool) {
+           // Calls into the protected VideoMedia helper.
+           registerMediaPort(port, pool);
+       }
+       ~CustomVideoPort() override {
+           if (id != PJSUA_INVALID_ID)
+               unregisterMediaPort();
+       }
+   };
 
-   MyVideoSource avi_src;
-   avi_src.registerMediaPort2(avi_port, pool);
+   CustomVideoPort avi_src;
+   avi_src.init(avi_port, pool);
 
    // Forward into call1's encoder and a local renderer:
    avi_src.startTransmit(call1.getEncodingVideoMedia(0),
                          VideoMediaTransmitParam());
    avi_src.startTransmit(my_renderer_vm, VideoMediaTransmitParam());
 
-When done, call :cpp:any:`pjsua_vid_conf_remove_port()` (or
-:cpp:func:`pj::Media::unregisterMediaPort()` in PJSUA2) to
-unregister the port.
+The destructor calls ``unregisterMediaPort()`` so the port is removed
+from the bridge when the wrapper goes out of scope.
 
 If the port's media format changes mid-session (for example, a video
 decoder learns new dimensions from incoming RTP), call
@@ -388,21 +343,46 @@ need this call.
 Asynchronous operations and completion callback
 -----------------------------------------------
 
-``pjsua_vid_conf_add_port``, ``remove_port``, ``connect``,
-``disconnect``, and ``update_port`` all return as soon as the operation
-is *queued*. The actual work happens on a media thread.
+``startTransmit``, ``stopTransmit``, ``registerMediaPort2``,
+``unregisterMediaPort``, and the underlying
+``pjsua_vid_conf_update_port`` all return as soon as the operation is
+*queued*. The actual work happens on a media thread.
 
-Apps that need to know when an operation has fully taken effect
-should implement the bridge op-completion callback —
-:cpp:any:`pjsua_callback::on_vid_conf_op_completed` in PJSUA-LIB or
-:cpp:func:`pj::Endpoint::onVideoMediaOpCompleted()` in PJSUA2. The
+Apps that need to know when an operation has fully taken effect should
+implement :cpp:func:`pj::Endpoint::onVideoMediaOpCompleted()`. The
 callback receives info identifying which operation completed and the
-operation's result code (``PJ_SUCCESS`` on success, or an error code
-if the operation failed). The callback fires from a media thread, so
-keep the handler short — defer any long or blocking work to your own
-thread.
+operation's result code (``PJ_SUCCESS`` on success, or an error code if
+the operation failed). The callback fires from a media thread, so keep
+the handler short — defer any long or blocking work to your own thread.
 
 A common pattern: kick off a connect, mark the call/UI state as
 "pending", and let the completion callback transition it to "active".
-Don't assume the connection is ready right after
-``pjsua_vid_conf_connect()`` returns.
+Don't assume the connection is ready right after ``startTransmit()``
+returns.
+
+
+PJSUA-LIB equivalents
+---------------------
+
++------------------------------------------------------+--------------------------------------------------------+
+| PJSUA2                                               | PJSUA-LIB                                              |
++======================================================+========================================================+
+| ``VideoMedia`` (slot wrapper)                        | :cpp:any:`pjsua_conf_port_id` (raw slot ID)            |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::VideoMedia::getPortId()`              | (the slot ID is the value itself)                      |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::Call::getEncodingVideoMedia()` /      | :cpp:any:`pjsua_call_get_vid_conf_port()` with         |
+| :cpp:func:`pj::Call::getDecodingVideoMedia()`        | ``PJMEDIA_DIR_ENCODING`` / ``PJMEDIA_DIR_DECODING``    |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::VideoPreview::getVideoMedia()`        | :cpp:any:`pjsua_vid_preview_get_vid_conf_port()`       |
++------------------------------------------------------+--------------------------------------------------------+
+| ``VideoMedia::startTransmit(sink, param)``           | :cpp:any:`pjsua_vid_conf_connect()`                    |
++------------------------------------------------------+--------------------------------------------------------+
+| ``VideoMedia::stopTransmit(sink)``                   | :cpp:any:`pjsua_vid_conf_disconnect()`                 |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::VideoMedia::registerMediaPort2()`     | :cpp:any:`pjsua_vid_conf_add_port()`                   |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::VideoMedia::unregisterMediaPort()`    | :cpp:any:`pjsua_vid_conf_remove_port()`                |
++------------------------------------------------------+--------------------------------------------------------+
+| :cpp:func:`pj::Endpoint::onVideoMediaOpCompleted()`  | :cpp:any:`pjsua_callback::on_vid_conf_op_completed`    |
++------------------------------------------------------+--------------------------------------------------------+

--- a/docs/source/specific-guides/video/conference.rst
+++ b/docs/source/specific-guides/video/conference.rst
@@ -157,7 +157,7 @@ behaviour is implemented by inserting a custom intermediate
 from one or more upstream sources and emits a single composed
 frame for downstream sinks. In PJSUA2, derive from ``VideoMedia``,
 register the underlying port via
-:cpp:func:`pj::VideoMedia::registerMediaPort2()`, then connect
+:cpp:func:`pj::VideoMedia::registerMediaPort()`, then connect
 upstream sources into it and it into the eventual sink like any other
 ``VideoMedia``.
 
@@ -239,7 +239,7 @@ PJSUA2 exposes per-stream VideoMedia objects directly on the call:
 For a local capture preview started with
 :cpp:func:`pj::VideoPreview::start()`, the corresponding VideoMedia is
 returned by :cpp:func:`pj::VideoPreview::getVideoMedia()`. For
-arbitrary ports added via ``registerMediaPort2()``, the slot is
+arbitrary ports added via ``registerMediaPort()``, the slot is
 available as ``getPortId()`` on the wrapping VideoMedia subclass.
 
 To inspect the bridge as a whole, use
@@ -343,7 +343,7 @@ need this call.
 Asynchronous operations and completion callback
 -----------------------------------------------
 
-``startTransmit``, ``stopTransmit``, ``registerMediaPort2``,
+``startTransmit``, ``stopTransmit``, ``registerMediaPort``,
 ``unregisterMediaPort``, and the underlying
 ``pjsua_vid_conf_update_port`` all return as soon as the operation is
 *queued*. The actual work happens on a media thread.
@@ -380,7 +380,7 @@ PJSUA-LIB equivalents
 +------------------------------------------------------+--------------------------------------------------------+
 | ``VideoMedia::stopTransmit(sink)``                   | :cpp:any:`pjsua_vid_conf_disconnect()`                 |
 +------------------------------------------------------+--------------------------------------------------------+
-| :cpp:func:`pj::VideoMedia::registerMediaPort2()`     | :cpp:any:`pjsua_vid_conf_add_port()`                   |
+| :cpp:func:`pj::VideoMedia::registerMediaPort()`     | :cpp:any:`pjsua_vid_conf_add_port()`                   |
 +------------------------------------------------------+--------------------------------------------------------+
 | :cpp:func:`pj::VideoMedia::unregisterMediaPort()`    | :cpp:any:`pjsua_vid_conf_remove_port()`                |
 +------------------------------------------------------+--------------------------------------------------------+

--- a/docs/source/specific-guides/video/orientation.rst
+++ b/docs/source/specific-guides/video/orientation.rst
@@ -1,6 +1,11 @@
 Setting Video Capture Orientation
 ==================================
 
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
 On mobile platforms the device rotates while a call is in progress, but
 the camera sensor's orientation does not, so transmitted video can end
 up sideways or upside-down at the peer. There are two strategies for
@@ -19,15 +24,6 @@ peer. Steps:
    rotation callbacks).
 2. Inside the callback, tell the capture device about the new
    orientation:
-
-   **PJSUA-LIB (C):**
-
-   .. code-block:: c
-
-      pjsua_vid_dev_set_setting(dev_id, PJMEDIA_VID_DEV_CAP_ORIENTATION,
-                                &new_orient, PJ_TRUE);
-
-   **PJSUA2 (C++):**
 
    .. code-block:: c++
 
@@ -56,16 +52,6 @@ default codec parameters assume landscape; if the call should start in
 portrait, configure the encoder format to portrait dimensions
 (``width < height``):
 
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   /* Sending 240 x 320 */
-   param.enc_fmt.det.vid.size.w = 240;
-   param.enc_fmt.det.vid.size.h = 320;
-
-**PJSUA2 (C++):**
-
 .. code-block:: c++
 
    // Sending 240 x 320
@@ -73,23 +59,8 @@ portrait, configure the encoder format to portrait dimensions
    param.encFmt.height = 320;
 
 …and tell the capture device the initial orientation **once**, after
-it is opened (e.g. by :cpp:any:`pjsua_vid_preview_start()` or implicitly
-by an outgoing/incoming video call):
-
-**PJSUA-LIB (C):**
-
-.. code-block:: c
-
-   /* On Android, portrait corresponds to PJMEDIA_ORIENT_ROTATE_270DEG */
-   current_orient = PJMEDIA_ORIENT_ROTATE_270DEG;
-
-   /* On iOS, portrait corresponds to PJMEDIA_ORIENT_ROTATE_90DEG */
-   current_orient = PJMEDIA_ORIENT_ROTATE_90DEG;
-
-   pjsua_vid_dev_set_setting(dev_id, PJMEDIA_VID_DEV_CAP_ORIENTATION,
-                             &current_orient, PJ_TRUE);
-
-**PJSUA2 (C++):**
+it is opened (e.g. by :cpp:func:`pj::VideoPreview::start()` or
+implicitly by an outgoing/incoming video call):
 
 .. code-block:: c++
 
@@ -101,7 +72,23 @@ by an outgoing/incoming video call):
                        .setCaptureOrient(dev_id, current_orient, true);
 
 After this initial setup, the application **must not** call
-``pjsua_vid_dev_set_setting()`` / ``setCaptureOrient()`` on subsequent
-orientation changes — doing so puts you back into Strategy A and forces
-the device to rotate. Instead, only update the remote peer over the
-out-of-band signaling channel.
+``setCaptureOrient()`` again on subsequent orientation changes — doing
+so puts you back into Strategy A and forces the device to rotate.
+Instead, only update the remote peer over the out-of-band signalling
+channel.
+
+
+PJSUA-LIB equivalents
+---------------------
+
++------------------------------------------------------+------------------------------------------------------+
+| PJSUA2                                               | PJSUA-LIB                                            |
++======================================================+======================================================+
+| ``Endpoint::vidDevManager().setCaptureOrient()``     | :cpp:any:`pjsua_vid_dev_set_setting()` with          |
+|                                                      | ``PJMEDIA_VID_DEV_CAP_ORIENTATION``                  |
++------------------------------------------------------+------------------------------------------------------+
+| ``VidCodecParam::encFmt.width`` / ``.height``        | ``pjmedia_vid_codec_param::enc_fmt.det.vid.size.w``  |
+|                                                      | / ``.h``                                             |
++------------------------------------------------------+------------------------------------------------------+
+| :cpp:func:`pj::VideoPreview::start()`                | :cpp:any:`pjsua_vid_preview_start()`                 |
++------------------------------------------------------+------------------------------------------------------+


### PR DESCRIPTION
## Summary

Follow-up to #45. Converts the four moved video deep-dives — `codec_params.rst`, `conference.rst`, `av_sync.rst`, `orientation.rst` — from PR #41's dual PJSUA-LIB / PJSUA2 snippet presentation to PJSUA2-first prose with a per-page PJSUA-LIB-equivalents table footer.

Pattern matches `keyframes.rst` introduced in #45:

- Top of page: short `.. tip::` — *"PJSUA-LIB readers — symbol equivalents are listed at the bottom of this page."*
- Body: PJSUA2-first prose and code samples; PJSUA-LIB code blocks removed.
- Bottom: `PJSUA-LIB equivalents` subsection — symbol-mapping table only, no full code samples.

> **Stacked on #45.** PR3 branches off PR2 (`docs/video-restructure`). Merge #45 first; this PR's diff will then narrow to PR3-only changes.

## Anchors preserved

`_guide_vidconf:` (conference.rst, heavily linked from `common/`, `get-started/android/`, and `components.rst`); `_vid_ug_av_sync:` (av_sync.rst).

## Code-claim audit

Every PJSUA2 / PJSUA-LIB symbol cited in the rewritten pages was verified against `pjproject` headers. Three real bugs were caught during the audit and fixed before push:

1. **`conference.rst`**: `pj::Media::unregisterMediaPort()` → `pj::VideoMedia::unregisterMediaPort()`. The base `Media` class does not declare it; the method is on `VideoMedia` (and separately on `AudioMedia`).

2. **`conference.rst`**: the custom-port example was incorrect on two counts — the method is named `registerMediaPort` (not `registerMediaPort2`) on `VideoMedia`, *and* both `registerMediaPort` and `unregisterMediaPort` are `protected`. The previous example `avi_src.registerMediaPort2(...)` on a bare `VideoMedia` instance would not compile. Replaced with the actual required pattern: a derived-class wrapper exposing `init()` and an `unregisterMediaPort()` destructor.

3. **`codec_params.rst` footer**: PJSUA-LIB column referenced a non-existent `pjmedia_format_detail` type. Replaced with the real access path `enc_fmt.det.vid.size.{w,h}` (and `fps.{num,denum}`, `avg_bps` / `max_bps`) on `pjmedia_video_format_detail`. Also corrected the fmtp row.

## Notable correctness item retained

`codec_params.rst` calls out that `AccountVideoConfig` initialises `rateControlMethod` to `SIMPLE_BLOCKING`, which differs from the PJSUA-LIB / PJMEDIA default of `SEND_THREAD` (`account.hpp:1312` vs `vid_stream.c:2310`). Footgun for PJSUA2 readers; explicitly noted in the prose.

## Test plan

- [x] Local Sphinx build is clean on all four touched files (179 pre-existing Breathe / auto-generated-API warnings on master are unchanged; no new warnings from this PR).
- [x] All PJSUA2 / PJSUA-LIB symbols cited verified against `pjproject` headers.
- [x] Anchors `_guide_vidconf:` and `_vid_ug_av_sync:` preserved at top of file.

Co-Authored-By: Claude Code
