### PR TITLE
Add 'Setting media direction' subsection to PJSUA2 call walkthrough

### DIFF
--- a/docs/source/pjsua2/using/call.rst
+++ b/docs/source/pjsua2/using/call.rst
@@ -216,12 +216,12 @@ the outgoing audio mid-call):
 
 For per-video-stream direction changes that don't go through a
 re-INVITE — e.g. flipping a video stream's direction locally
-without renegotiation — see ``Call::vidSetStream()`` with the
-``PJSUA_CALL_VID_STRM_CHANGE_DIR`` operation in
+without renegotiation — see :cpp:func:`pj::Call::vidSetStream` with
+the ``PJSUA_CALL_VID_STRM_CHANGE_DIR`` operation in
 :any:`/pjsua2/using/media_video`. Putting a call on hold is the
-more common case and is handled by ``Call::setHold()`` /
-``Call::reinvite()`` directly; you don't need to drive ``mediaDir``
-manually for hold.
+more common case and is handled by :cpp:func:`pj::Call::setHold` /
+:cpp:func:`pj::Call::reinvite` directly; you don't need to drive
+``mediaDir`` manually for hold.
 
 .. note::
 

--- a/docs/source/pjsua2/using/call.rst
+++ b/docs/source/pjsua2/using/call.rst
@@ -237,7 +237,7 @@ more common case and is handled by :cpp:func:`pj::Call::setHold` /
    mode, or a user-defined payload in ``KA_USER`` mode). This is
    what you set via ``mediaDir``.
    **Disabled** is a stream rejected with ``port=0`` on the m-line
-   per RFC 3264: no resources allocated, no codec negotiation, no
+   per :rfc:`3264`: no resources allocated, no codec negotiation, no
    RTP, no RTCP, no keep-alive — the m-line is preserved only for
    index alignment with the original offer. ``mediaDir`` does not
    express disabled — for that, lower ``audioCount`` /

--- a/docs/source/pjsua2/using/call.rst
+++ b/docs/source/pjsua2/using/call.rst
@@ -141,9 +141,113 @@ Below is a sample code to connect the call to the sound device when the media is
         }
     }
 
-When the audio media becomes inactive (for example when the call is put on hold), there is no need to 
-stop the call's audio media transmission since they will be removed automatically from the conference 
+When the audio media becomes inactive (for example when the call is put on hold), there is no need to
+stop the call's audio media transmission since they will be removed automatically from the conference
 bridge, and this will automatically remove all connections to/from the call.
+
+
+Setting media direction
+------------------------
+By default each media stream is negotiated as ``sendrecv``. To
+configure a different direction (sendonly, recvonly, or inactive)
+for one or more streams in a call, set the ``PJSUA_CALL_SET_MEDIA_DIR``
+flag on :cpp:any:`pj::CallSetting::flag` and populate
+:cpp:any:`pj::CallSetting::mediaDir` with the per-stream direction.
+
+The direction is honoured wherever ``CallSetting`` is accepted —
+``Call::makeCall()``, ``Call::answer()``, ``Call::reinvite()``,
+``Call::update()``, and the ``onCallRxOffer()`` / ``onCallRxReinvite()``
+callbacks. It then persists for subsequent offers and answers on
+the same call. Note that the direction can only be **narrowed**
+once set: a stream that was set to ``PJMEDIA_DIR_ENCODING`` can
+become inactive on a later re-INVITE but will not flip back to
+``sendrecv`` from the local side.
+
+The index of each ``mediaDir`` entry corresponds to the provisional
+media slot in :cpp:any:`pj::CallInfo::provMedia`. For offers that
+add new media (initial offer, or a re-INVITE that adds streams),
+the index orders all new **audio** media first, then **video**.
+So a new call with two audio streams and one video stream uses
+``mediaDir[0]`` and ``mediaDir[1]`` for the audios and ``mediaDir[2]``
+for the video.
+
+**Example — make an outgoing call as receive-only:**
+
+.. code-block:: c++
+
+    CallOpParam prm(true);
+    prm.opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
+    prm.opt.mediaDir.push_back(PJMEDIA_DIR_DECODING);  // audio: recvonly
+
+    try {
+        call->makeCall(dest_uri, prm);
+    } catch(Error& err) {
+    }
+
+**Example — answer with a one-way (send-only) audio path:**
+
+.. code-block:: c++
+
+    void MyAccount::onIncomingCall(OnIncomingCallParam &iprm) override
+    {
+        Call *call = new MyCall(*this, iprm.callId);
+        CallOpParam prm;
+        prm.statusCode = PJSIP_SC_OK;
+        prm.opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
+        prm.opt.mediaDir.push_back(PJMEDIA_DIR_ENCODING);
+        call->answer(prm);
+    }
+
+**Example — narrow an existing stream via re-INVITE** (e.g. mute
+the outgoing audio mid-call):
+
+.. code-block:: c++
+
+    CallOpParam prm(true);
+    prm.opt.flag |= PJSUA_CALL_SET_MEDIA_DIR;
+    prm.opt.mediaDir.push_back(PJMEDIA_DIR_DECODING);  // recvonly
+
+    try {
+        call->reinvite(prm);
+    } catch(Error& err) {
+    }
+
+For per-video-stream direction changes that don't go through a
+re-INVITE — e.g. flipping a video stream's direction locally
+without renegotiation — see ``Call::vidSetStream()`` with the
+``PJSUA_CALL_VID_STRM_CHANGE_DIR`` operation in
+:any:`/pjsua2/using/media_video`. Putting a call on hold is the
+more common case and is handled by ``Call::setHold()`` /
+``Call::reinvite()`` directly; you don't need to drive ``mediaDir``
+manually for hold.
+
+.. note::
+
+   *Inactive* and *disabled* are different SDP concepts.
+   **Inactive** (``PJMEDIA_DIR_NONE`` here, ``a=inactive`` on the
+   wire) keeps the stream negotiated — real port, codec list,
+   RTCP still flowing (Sender / Receiver Reports keep updating).
+   RTP is the part that's suppressed by ``a=inactive``; if
+   PJMEDIA's media keep-alive is enabled
+   (``PJMEDIA_STREAM_ENABLE_KA``, off by default) the stream still
+   emits keep-alive packets every few seconds — those are also
+   RTP packets (empty RTP frame in the default ``KA_EMPTY_RTP``
+   mode, or a user-defined payload in ``KA_USER`` mode). This is
+   what you set via ``mediaDir``.
+   **Disabled** is a stream rejected with ``port=0`` on the m-line
+   per RFC 3264: no resources allocated, no codec negotiation, no
+   RTP, no RTCP, no keep-alive — the m-line is preserved only for
+   index alignment with the original offer. ``mediaDir`` does not
+   express disabled — for that, lower ``audioCount`` /
+   ``videoCount`` / ``textCount`` to drop the streams you don't
+   want, optionally combined with the
+   ``PJSUA_CALL_INCLUDE_DISABLED_MEDIA`` flag to keep the
+   placeholder m-line in the offer.
+
+PJSUA-LIB applications use the same flag plus the
+:cpp:any:`pjsua_call_setting::media_dir` array
+(``PJMEDIA_MAX_SDP_MEDIA`` entries instead of a vector).
+
 
 Call Operations
 -------------------

--- a/docs/source/pjsua2/using/call.rst
+++ b/docs/source/pjsua2/using/call.rst
@@ -155,10 +155,12 @@ flag on :cpp:any:`pj::CallSetting::flag` and populate
 :cpp:any:`pj::CallSetting::mediaDir` with the per-stream direction.
 
 The direction is honoured wherever ``CallSetting`` is accepted —
-``Call::makeCall()``, ``Call::answer()``, ``Call::reinvite()``,
-``Call::update()``, and the ``onCallRxOffer()`` / ``onCallRxReinvite()``
-callbacks. It then persists for subsequent offers and answers on
-the same call. Note that the direction can only be **narrowed**
+:cpp:func:`pj::Call::makeCall()`, :cpp:func:`pj::Call::answer()`,
+:cpp:func:`pj::Call::reinvite()`, :cpp:func:`pj::Call::update()`, and
+the :cpp:func:`pj::Call::onCallRxOffer()` /
+:cpp:func:`pj::Call::onCallRxReinvite()` callbacks. It then persists for
+subsequent offers and answers on the same call. Note that the direction
+can only be **narrowed**
 once set: a stream that was set to ``PJMEDIA_DIR_ENCODING`` can
 become inactive on a later re-INVITE but will not flip back to
 ``sendrecv`` from the local side.


### PR DESCRIPTION
## Summary

Closes Tier 2 #10 from the docs enhancement report (Media Direction Control in Calls — pjsip/pjproject#2705, merged into 2.11, currently undocumented). Adds a *Setting media direction* subsection to `pjsua2/using/call.rst`, slotted between "Working with Call's Audio Media" and "Call Operations" — same neighbourhood as hold, since hold is itself a media-direction operation.

## What's new

- The flag pattern — `PJSUA_CALL_SET_MEDIA_DIR` on `CallSetting::flag`, with per-stream direction in `CallSetting::mediaDir`.
- Where it's honoured — `makeCall` / `answer` / `reinvite` / `update`, plus the `onCallRxOffer` / `onCallRxReinvite` callbacks.
- Persistence + narrowing-only behaviour spelled out (a stream narrowed to sendonly can become inactive on a later re-INVITE but won't flip back to sendrecv from the local side).
- Index ordering rule — `mediaDir[i]` matches `CallInfo::provMedia[i]`; new media is ordered audio-first then video.
- Three worked examples: outgoing call as recvonly, answer with sendonly audio, re-INVITE to narrow an existing stream.
- Cross-link to `Call::vidSetStream` + `PJSUA_CALL_VID_STRM_CHANGE_DIR` for the per-video-stream local direction-modify path that doesn't go through re-INVITE.
- Cross-link to `Call::setHold` for the hold case (the common trigger; doesn't need manual `mediaDir`).
- A `.. note::` block at the bottom distinguishing **inactive** (`PJMEDIA_DIR_NONE` / `a=inactive` — stream still negotiated, RTCP still flowing, PJMEDIA keep-alive still firing if enabled — and noting keep-alive packets are themselves RTP packets in the default `KA_EMPTY_RTP` mode) from **disabled** (`port=0` m-line per RFC 3264 — no resources, no codecs, no RTP, no RTCP, no keep-alive). `mediaDir` expresses inactive but not disabled; disabled is set via `audioCount` / `videoCount` / `textCount` plus `PJSUA_CALL_INCLUDE_DISABLED_MEDIA`.
- One-line PJSUA-LIB equivalent at the end (`pjsua_call_setting::media_dir[]`).

## Code-claim audit

Every API symbol and behavioural claim verified against `pjproject` source headers (`call.hpp`, `pjsua.h`, `pjmedia/types.h`, `pjmedia/config.h`). Notable items confirmed:

- `pjmedia_dir` enum values map exactly: `NONE = 0` (inactive), `ENCODING = 1` (sendonly), `DECODING = 2` (recvonly), `ENCODING_DECODING = 3` (sendrecv).
- Persistence + narrowing-only rule quoted directly from the doxygen comment on `CallSetting::mediaDir`.
- Index-ordering rule (audio-first then video) quoted from the same doxygen comment.
- Keep-alive: confirmed off by default (`PJMEDIA_STREAM_ENABLE_KA = 0`), and that the packets are themselves RTP packets in the default `KA_EMPTY_RTP` mode — not a separate non-RTP control channel as I'd initially framed it.

## Test plan

- [x] Local Sphinx build is clean on the touched file (179 pre-existing Breathe / auto-generated-API warnings on master are unchanged; no new warnings from this PR).
- [x] All API symbols and behaviours verified against `pjproject` headers.

Co-Authored-By: Claude Code
