### PR TITLE
docs: cross-link Lyra codec (experimental)

### DIFF
--- a/docs/source/api/pjmedia/pjmedia-codec.rst
+++ b/docs/source/api/pjmedia/pjmedia-codec.rst
@@ -150,8 +150,8 @@ Google's open-source neural speech codec, targeting low bit rates
 - External dependency: build the Lyra library from
   https://github.com/google/lyra first.
 - Enable in PJSIP via ``./configure --with-lyra=DIR`` (autoconf),
-  ``find_package(Lyra)`` (CMake), or ``PJMEDIA_HAS_LYRA_CODEC 1``
-  in ``config_site.h``.
+  ``find_package(Lyra)`` (CMake), or by defining
+  ``PJMEDIA_HAS_LYRA_CODEC`` to ``1`` in ``config_site.h``.
 - Default clock rate: 16 kHz only. Toggle 8 / 32 / 48 kHz via
   ``PJMEDIA_CODEC_LYRA_HAS_*KHZ`` macros.
 - Requires four model files (``lyra_config.binarypb``,

--- a/docs/source/api/pjmedia/pjmedia-codec.rst
+++ b/docs/source/api/pjmedia/pjmedia-codec.rst
@@ -134,6 +134,33 @@ Linear/PCM 8/16bit mono/stereo
 
 - Code documentation: :doc:`PCM/Linear 16bit </api/generated/pjmedia/group/group__PJMED__L16>`
 
+.. _lyra:
+
+Lyra (experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Google's open-source neural speech codec, targeting low bit rates
+(3200, 6000, 9200 bps) at speech-quality fidelity.
+
+- **Experimental.** Lyra is not standardised — there is no RFC,
+  no IANA-registered MIME type, and no formally specified SDP /
+  RTP payload format. The ``fmtp:bitrate=N`` parameter PJSIP
+  advertises is an internal convention; expect interop limited to
+  peers running the same PJSIP Lyra integration.
+- External dependency: build the Lyra library from
+  https://github.com/google/lyra first.
+- Enable in PJSIP via ``./configure --with-lyra=DIR`` (autoconf),
+  ``find_package(Lyra)`` (CMake), or ``PJMEDIA_HAS_LYRA_CODEC 1``
+  in ``config_site.h``.
+- Default clock rate: 16 kHz only. Toggle 8 / 32 / 48 kHz via
+  ``PJMEDIA_CODEC_LYRA_HAS_*KHZ`` macros.
+- Requires four model files (``lyra_config.binarypb``,
+  ``lyragan.tflite``, ``quantizer.tflite``,
+  ``soundstream_encoder.tflite``) at the configured ``model_path``.
+- License: Apache 2.0. See :doc:`/overview/license_3rd_party`.
+- Code documentation: :doc:`Lyra </api/generated/pjmedia/group/group__PJMED__LYRA>`
+
+
 .. _opencore_amr:
 
 OpenCore AMR NB/WB

--- a/docs/source/common/common_codecs.rst
+++ b/docs/source/common/common_codecs.rst
@@ -18,6 +18,7 @@ Audio Codecs
 - :ref:`ilbc`
 - :ref:`ipp` (G.722.1, G.723.1, G.726, G.728, G.729, AMR, and AMR-WB)
 - :ref:`l16`
+- :ref:`lyra` (experimental)
 - :any:`/specific-guides/audio/opencore-amr`
 - :ref:`opus`
 - :ref:`l16`

--- a/docs/source/common/common_codecs.rst
+++ b/docs/source/common/common_codecs.rst
@@ -21,7 +21,6 @@ Audio Codecs
 - :ref:`lyra` (experimental)
 - :any:`/specific-guides/audio/opencore-amr`
 - :ref:`opus`
-- :ref:`l16`
 - :ref:`passthrough`
 - :ref:`silk`
 - :ref:`speex`

--- a/docs/source/overview/license_3rd_party.rst
+++ b/docs/source/overview/license_3rd_party.rst
@@ -555,7 +555,30 @@ ffmpeg and libx264
    * - License
      - Please consult the Ffmpeg and libx264 websites. 
    * - Usage
-     - See :ref:`ffmpeg`. 
+     - See :ref:`ffmpeg`.
+
+
+Lyra (experimental)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+.. list-table::
+   :header-rows: 0
+
+   * - Software
+     - https://github.com/google/lyra
+   * - Location
+     - - :source:`pjmedia/include/pjmedia-codec/lyra.h`
+       - :source:`pjmedia/src/pjmedia-codec/lyra.cpp`
+   * - Description
+     - Google's open-source neural speech codec, integrated as an
+       experimental low-bitrate option in PJSIP. Not standardised
+       (no RFC, no IANA-registered MIME type, no formal SDP/RTP
+       payload spec); interop is essentially limited to other
+       PJSIP peers running the same integration.
+   * - License
+     - Apache 2.0. See
+       https://github.com/google/lyra/blob/main/LICENSE
+   * - Usage
+     - See :ref:`lyra`
 
 
 Oboe


### PR DESCRIPTION
## Summary
Cross-links the Lyra codec from the docs site, complementing the in-source `@defgroup PJMED_LYRA` expansion in pjproject#4955.

**Added:**
- `common/common_codecs.rst` — Lyra entry in the audio codec list, flagged `(experimental)`.
- `api/pjmedia/pjmedia-codec.rst` — new `_lyra:` section with build pointers (autoconf `--with-lyra`, CMake `find_package(Lyra)`, `config_site.h` fallback), the default-clockrate note (16 kHz only), required model files, and a link to the doxygen-generated page.
- `overview/license_3rd_party.rst` — Lyra entry in the External Third Party Software section, alphabetised between ffmpeg and Oboe. Apache 2.0.

**Lyra is labelled experimental** at every entry point: not standardised, no RFC, no IANA-registered MIME type, no formal SDP/RTP payload spec; the `fmtp:bitrate=N` parameter PJSIP advertises is an internal convention.

## Test plan
- [x] `sphinx-build -b html` clean for the touched files.
- [x] All `:ref:` / `:doc:` cross-references resolve (including the forward-link to `:doc:`Lyra </api/generated/pjmedia/group/group__PJMED__LYRA>`` which lands once pjproject#4955 merges and RTD regenerates the doxygen XML).

Companion PR: pjproject#4955 (in-source `@defgroup PJMED_LYRA` expansion).

Co-Authored-By: Claude Code