### PR TITLE
Fix auto-generated group page H1 — use @defgroup label, not raw ID

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ import os
 import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 
 
 # Which pjproject tag to checkout to create the documentation.
@@ -87,6 +88,37 @@ if is_in_rtd:
                 os.remove(f'api{os.sep}generated{os.sep}{api_dir}{os.sep}{f}')
             except:
                 pass
+
+        # breathe-apidoc names every group page "Group <RAW_ID>" (e.g.
+        # "Group PJMED_STRM"), ignoring the human-readable title from
+        # @defgroup. Read each group's doxygen XML and rewrite the H1
+        # with the actual title (e.g. "Streams").
+        xml_dir = f'pjproject{os.sep}{doxy_dir}{os.sep}docs{os.sep}xml'
+        rst_dir = f'api{os.sep}generated{os.sep}{api_dir}{os.sep}group'
+        if os.path.isdir(rst_dir):
+            for fname in sorted(os.listdir(rst_dir)):
+                if not (fname.startswith('group__') and fname.endswith('.rst')):
+                    continue
+                xml_path = os.path.join(xml_dir, fname[:-4] + '.xml')
+                if not os.path.exists(xml_path):
+                    continue
+                try:
+                    title_el = ET.parse(xml_path).getroot().find(
+                        './/compounddef/title')
+                except ET.ParseError as e:
+                    print(f'Warning: cannot parse {xml_path}: {e}')
+                    continue
+                if title_el is None or not (title_el.text or '').strip():
+                    continue
+                title = title_el.text.strip()
+                rst_path = os.path.join(rst_dir, fname)
+                with open(rst_path, 'rt') as f:
+                    lines = f.read().splitlines()
+                if len(lines) >= 2 and lines[0].startswith('Group '):
+                    lines[0] = title
+                    lines[1] = '=' * len(title)
+                    with open(rst_path, 'wt') as f:
+                        f.write('\n'.join(lines) + '\n')
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
## Summary

Every auto-generated group page on the docs site renders its H1 as `Group <RAW_ID>` (e.g. `Group PJMED_STRM`, `Group PJMEDIA_SESSION`, `Group PJMED_OPUS`) instead of the human-readable label from the `@defgroup` directive in the source headers.

Source — `pjmedia/include/pjmedia/stream.h`:

```c
* @defgroup PJMED_STRM Streams
```

Doxygen XML faithfully captures both:

```xml
<compoundname>PJMED_STRM</compoundname>
<title>Streams</title>
```

But `breathe-apidoc` (`/usr/lib/python3/dist-packages/breathe/apidoc.py:110`) emits:

```python
text = format_heading(1, "%s %s" % (TYPEDICT[package_type], package))
```

…where `TYPEDICT['group'] = 'Group'` and `package` is the raw doxygen ID. The XML `<title>` is never read.

## Fix

Adds a post-process step in `docs/source/conf.py`, immediately after the existing `breathe-apidoc` invocation. For each generated `group__*.rst`, the script reads the matching doxygen XML, extracts `<compounddef>/<title>`, and rewrites the file's H1 + underline. Defensive checks:

- Skip files that don't have a matching XML (e.g. stale .rst from a previous doxygen run).
- Skip XMLs that fail to parse (warn and continue).
- Skip XMLs without a `<title>` element or with empty title (no-op, leaves the original `Group <ID>` heading in place).
- Skip .rst files whose first line doesn't start with `Group ` (don't accidentally double-rewrite).

Only runs inside the existing `if is_in_rtd:` gate — same gate that already wraps the `breathe-apidoc` invocation, so local builds without doxygen output are unaffected.

## Verification

Tested locally on pjmedia:

- 104 group `.rst` files rewritten (every group page that has corresponding doxygen XML).
- Sphinx full rebuild clean (no new warnings; the 3 pre-existing toctree warnings are unrelated).
- Spot-checked rendered H1 values:

| Group ID | H1 before | H1 after |
| --- | --- | --- |
| `PJMED_STRM` | `Group PJMED_STRM` | `Streams` |
| `PJMED_VID_STRM` | `Group PJMED_VID_STRM` | `Video streams` |
| `PJMED_TXT_STRM` | `Group PJMED_TXT_STRM` | `Text streams` |
| `PJMEDIA_SESSION` | `Group PJMEDIA_SESSION` | `Media Sessions` |
| `PJMEDIA_CONF` | `Group PJMEDIA_CONF` | `Conference Bridge` |
| `PJMED_OPUS` | `Group PJMED_OPUS` | `Opus Codec Family` |

## Origin

Surfaced while reviewing pjproject_docs#56 — the new "Customizing the Audio Stream Port" guide links to `/api/generated/pjmedia/group/group__PJMED__STRM` and the link text overrides solve only one page. The destination's H1 still reads `Group PJMED_STRM`, and the same condition affects every other auto-generated group page in the project.

## Test plan

- [ ] CI green.
- [ ] On Read the Docs preview, spot-check several group pages across pjlib / pjlib-util / pjnath / pjmedia / pjsip — H1 should be the `@defgroup` title in each case.
- [ ] Confirm no regression on group pages whose doxygen XML lacks a `<title>` (the post-process skips them; H1 stays as `Group <ID>` rather than crashing or silently emptying).

Co-Authored-By: Claude Code