### PR TITLE
docs: ICE guides — trickle expanded, manual host candidates, TURN TCP/TLS

### DIFF
--- a/docs/source/specific-guides/network_nat/manual_ice_host_cand.rst
+++ b/docs/source/specific-guides/network_nat/manual_ice_host_cand.rst
@@ -57,10 +57,10 @@ Each manual address is processed as follows
   IPv4 are added only on IPv4 STUN transports, and IPv6 entries only
   on IPv6 transports. Mixed-family entries are filtered out for the
   wrong-family transport.
-- **Port is inherited from the media socket.** The port byte you set
-  on the manual address is overwritten with the port of the
+- **Port is inherited from the media socket.** Whatever port value
+  you set on the manual address is overwritten with the port of the
   auto-detected base — i.e. the actual port the media socket is
-  bound to. Use any value (e.g. 0) when initialising the address.
+  bound to. Leave the port at 0 when initialising the address.
 - **Foundation is computed from the base address**, matching how
   auto-detected hosts are foundationed, so pairing behaves the same.
 - **Priority follows declaration order**: manual hosts are inserted
@@ -84,8 +84,11 @@ PJSUA2 usage
 ------------
 
 Set :cpp:any:`pj::AccountNatConfig::iceManualHost` to a vector of
-bare IP-address strings. Both IPv4 and IPv6 literals work; hostnames
-are not resolved, so the value must already be a numeric address.
+bare host-address strings. Numeric IPv4 and IPv6 literals are the
+common case; hostnames are also accepted (resolved through the
+platform resolver by :cpp:any:`pj_sockaddr_set_str_addr()`), but
+since manual candidates exist precisely to pin a specific address,
+using a literal is normally clearer.
 
 .. code-block:: c++
 
@@ -107,9 +110,9 @@ Notes:
 
 - Strings are parsed via :cpp:any:`pj_sockaddr_set_str_addr()`. Use
   a bare host address (e.g. ``"10.0.0.5"`` or ``"2001:db8::5"``) —
-  not ``host:port``, and not a bracketed IPv6 literal like
-  ``[::1]``. Hostnames are resolved via the platform resolver, but
-  manual host candidates are normally a literal IP.
+  **not** ``host:port``, and **not** a bracketed IPv6 literal like
+  ``[::1]``. Both numeric literals and hostnames are accepted (the
+  latter via :cpp:any:`pj_getaddrinfo`).
 - The field is a :cpp:any:`pj::SocketAddressVector`, a typedef for
   :cpp:any:`pj::StringVector`. It is serialised by
   :cpp:any:`pj::AccountConfig::readObject` /

--- a/docs/source/specific-guides/network_nat/manual_ice_host_cand.rst
+++ b/docs/source/specific-guides/network_nat/manual_ice_host_cand.rst
@@ -1,0 +1,211 @@
+.. _guide_manual_ice_host_cand:
+
+Manual ICE Host Candidates
+==========================
+
+.. contents:: Table of Contents
+    :depth: 2
+
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
+
+Overview
+--------
+
+ICE host candidates are normally discovered by enumerating the local
+network interfaces and binding the media socket to each. That works
+well on a typical desktop or mobile device but breaks in environments
+where the address the rest of the network reaches you on isn't an
+address the host's kernel sees:
+
+- **Docker / container deployments** — the application sees the
+  container's private bridge address (``172.17.0.x`` on
+  ``docker0``), but peers reach it on the host's published address.
+- **NAT'd virtualisation** — VMs that use host-only or NAT
+  networking from the hypervisor.
+- **Split-tunnel VPNs** — the tunnel address is correct, but the
+  physical-NIC address is not.
+- **Multi-homed servers** — a service-discovery system that hands
+  out only one of several local addresses for the media path.
+
+Before this feature existed, the workaround was to point ICE at a
+STUN server that observed the correct external mapping and rely on
+the srflx candidate. That still works, but adds a STUN dependency
+for the simplest case — a single static mapping known up front.
+
+PJSIP 2.17 (:pr:`4618`) adds *manual host candidates*: the
+application supplies extra host candidate addresses up front and
+ICE treats them as if they had been auto-discovered from a local
+interface.
+
+
+How it works
+------------
+
+Manual candidates are **additive** — they augment, not replace, the
+auto-detected host candidates. ICE will offer all of them as host
+candidates in the initial SDP and the peer will pair-test against
+each one as part of normal ICE connectivity checks.
+
+Each manual address is processed as follows
+(:sourcedir:`pjnath/src/pjnath/ice_strans.c`):
+
+- **Address family must match the transport.** Manual entries for
+  IPv4 are added only on IPv4 STUN transports, and IPv6 entries only
+  on IPv6 transports. Mixed-family entries are filtered out for the
+  wrong-family transport.
+- **Port is inherited from the media socket.** The port byte you set
+  on the manual address is overwritten with the port of the
+  auto-detected base — i.e. the actual port the media socket is
+  bound to. Use any value (e.g. 0) when initialising the address.
+- **Foundation is computed from the base address**, matching how
+  auto-detected hosts are foundationed, so pairing behaves the same.
+- **Priority follows declaration order**: manual hosts are inserted
+  with descending local preference, so the first manual entry is
+  preferred over the second, and so on.
+- **Total host count is capped** by
+  :cpp:any:`pj::AccountNatConfig::iceMaxHostCands` /
+  :cpp:any:`pjsua_ice_config::ice_max_host_cands` (default ``-1``,
+  i.e. :c:macro:`PJ_ICE_ST_MAX_CAND`, currently 64). Auto-detected
+  and manual host candidates share this budget. PJSUA2 additionally
+  raises :c:macro:`PJ_ETOOMANY` if the input vector exceeds the
+  internal array size.
+
+The feature does not change SIP-layer addressing. SIP requests and
+the SDP ``c=`` line still reflect the addresses chosen by the SIP
+transport (``pjsua_transport_config::public_addr``, etc.). Manual
+host candidates only affect the ICE candidate list inside the SDP.
+
+
+PJSUA2 usage
+------------
+
+Set :cpp:any:`pj::AccountNatConfig::iceManualHost` to a vector of
+bare IP-address strings. Both IPv4 and IPv6 literals work; hostnames
+are not resolved, so the value must already be a numeric address.
+
+.. code-block:: c++
+
+   AccountConfig acfg;
+   // ... existing config ...
+   acfg.natConfig.iceEnabled       = true;
+   acfg.natConfig.iceManualHost.clear();
+   acfg.natConfig.iceManualHost.push_back("203.0.113.5");          // public IPv4
+   acfg.natConfig.iceManualHost.push_back("2001:db8::5");          // public IPv6
+
+   try {
+       account.create(acfg);   // or account.modify(acfg);
+   } catch(Error& err) {
+       // PJ_EINVAL if any string failed to parse,
+       // PJ_ETOOMANY if vector exceeds the internal cap.
+   }
+
+Notes:
+
+- Strings are parsed via :cpp:any:`pj_sockaddr_set_str_addr()`. Use
+  a bare host address (e.g. ``"10.0.0.5"`` or ``"2001:db8::5"``) —
+  not ``host:port``, and not a bracketed IPv6 literal like
+  ``[::1]``. Hostnames are resolved via the platform resolver, but
+  manual host candidates are normally a literal IP.
+- The field is a :cpp:any:`pj::SocketAddressVector`, a typedef for
+  :cpp:any:`pj::StringVector`. It is serialised by
+  :cpp:any:`pj::AccountConfig::readObject` /
+  :cpp:any:`pj::AccountConfig::writeObject` so settings persist
+  through XML/JSON config.
+
+
+PJSUA-LIB usage
+---------------
+
+Populate :cpp:any:`pjsua_ice_config::ice_manual_host` (an array of
+:cpp:any:`pj_sockaddr`) and set
+:cpp:any:`pjsua_ice_config::ice_manual_host_cnt`.
+
+.. code-block:: c
+
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_config_default(&acc_cfg);
+
+    acc_cfg.ice_cfg_use            = PJSUA_ICE_CONFIG_USE_CUSTOM;
+    acc_cfg.ice_cfg.enable_ice     = PJ_TRUE;
+
+    pj_str_t v4 = pj_str("203.0.113.5");
+    pj_str_t v6 = pj_str("2001:db8::5");
+    pj_sockaddr_set_str_addr(pj_AF_INET(),
+                             &acc_cfg.ice_cfg.ice_manual_host[0], &v4);
+    pj_sockaddr_set_str_addr(pj_AF_INET6(),
+                             &acc_cfg.ice_cfg.ice_manual_host[1], &v6);
+    acc_cfg.ice_cfg.ice_manual_host_cnt = 2;
+
+    pjsua_acc_id acc_id;
+    pjsua_acc_add(&acc_cfg, PJ_TRUE, &acc_id);
+
+Manual host candidates are configured per account; the global
+:cpp:any:`pjsua_media_config` does **not** expose
+``ice_manual_host`` / ``ice_manual_host_cnt``. To apply the same
+manual addresses to every account, set them on each account config.
+
+A standalone PJNATH application configures the array on
+:cpp:any:`pj_ice_strans_stun_cfg::manual_host` (with
+:cpp:any:`pj_ice_strans_stun_cfg::manual_host_cnt`) inside
+:cpp:any:`pj_ice_strans_cfg`, before calling
+:cpp:any:`pj_ice_strans_create()`.
+
+
+pjsua CLI
+~~~~~~~~~
+
+There is no ``--ice-manual-host`` command-line option in the
+pjsua sample app at present. Applications that want to set manual
+hosts have to use the API.
+
+
+When manual hosts are not enough
+--------------------------------
+
+Manual host candidates only solve the ICE side of the address
+mismatch. If the SIP signalling path also goes through NAT, the
+addresses in the SIP request URI, ``Contact`` header, and SDP
+``c=`` line still need their own handling — typically via
+:cpp:any:`pjsua_transport_config::public_addr` for the SIP
+transport, and STUN or :cpp:any:`pjsua_acc_config::nat64_opt` for
+SDP. See :doc:`nat_guide` for the broader NAT picture.
+
+Manual host candidates also won't help when the inbound address is
+not directly routable to the media socket — for example, when the
+container's NAT does not forward UDP at all. In that case TURN
+relaying is still required; configure a TURN server in addition to
+the manual host. See :doc:`turn_tcp_tls`.
+
+
+PJSUA-LIB equivalents
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - PJSUA2
+     - PJSUA-LIB
+   * - :cpp:any:`pj::AccountNatConfig::iceManualHost`
+       (``SocketAddressVector`` of address strings)
+     - :cpp:any:`pjsua_ice_config::ice_manual_host` /
+       :cpp:any:`pjsua_ice_config::ice_manual_host_cnt`
+       (``pj_sockaddr`` array)
+   * - :cpp:any:`pj::AccountNatConfig::iceMaxHostCands`
+     - :cpp:any:`pjsua_ice_config::ice_max_host_cands`
+   * - (configured via
+       :cpp:any:`pj::AccountNatConfig::iceManualHost`)
+     - Standalone PJNATH:
+       :cpp:any:`pj_ice_strans_stun_cfg::manual_host` /
+       :cpp:any:`pj_ice_strans_stun_cfg::manual_host_cnt`
+
+
+References
+----------
+
+- Feature PR: :pr:`4618`
+- ICE candidate types and pairing: :rfc:`8445`

--- a/docs/source/specific-guides/network_nat/trickle_ice.rst
+++ b/docs/source/specific-guides/network_nat/trickle_ice.rst
@@ -1,48 +1,326 @@
+.. _guide_trickle_ice:
+
 Using Trickle ICE
 ====================
 
 .. contents:: Table of Contents
     :depth: 2
 
-Brief info about Trickle ICE
---------------------------------
+.. tip::
 
-Trickle ICE is a supplementary mode of ICE operation in which candidates can be exchanged incrementally as soon as they become available (and simultaneously with the gathering of other candidates).  Connectivity checks can also start as soon as candidate pairs have been created.  Because Trickle ICE enables candidate gathering and connectivity checks to be done in parallel, the method can considerably accelerate the process of establishing a communication session.
-
-Two operation modes of trickle ICE:
-
- #. Full trickle, the typical mode of operation for Trickle ICE agents, an agent is supposed to enable this mode only when it knows that remote supports trickle ICE. Determining support of trickle ICE can be done by following the recommendations described :rfc:`8838#section-3` and specifically for :rfc:`8840#section-5`.
-
- #. Half trickle, mode of operation in which the initiator gathers a full generation of candidates strictly before creating and conveying the initial ICE description. Once conveyed, this candidate information can be processed by regular ICE agents, which do not require support for Trickle ICE. It also allows Trickle ICE capable responders to still gather candidates and perform connectivity checks in a non-blocking way, thus providing roughly "half" the advantages of Trickle ICE. The half trickle mechanism is mostly meant for use when the responder's support for Trickle ICE cannot be confirmed prior to conveying the initial ICE description.
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
 
 
-How to enable
---------------------------------
-For app using PJSUA
-~~~~~~~~~~~~~~~~~~~~~~~~
- #. Enable and configure ICE as usual.
- #. Configure trickle ICE, it can be configured globally (for all SIP accounts) or per account basis:
+Overview
+--------
 
-    - global setting: set :cpp:any:`pjsua_media_config::ice_opt::trickle` to :cpp:any:`PJ_ICE_SESS_TRICKLE_HALF` or :cpp:any:`PJ_ICE_SESS_TRICKLE_FULL`.
-    - account setting:
+ICE establishes a media path by gathering local candidates (host,
+STUN-derived server-reflexive, TURN-derived relayed) and probing them
+pairwise against the peer's candidates. In the classic model
+(:rfc:`8445`) each side must finish gathering before signalling
+begins, so the call setup blocks for the slowest STUN/TURN response.
 
-      - set :cpp:any:`pjsua_acc_config::ice_cfg_use` to :cpp:any:`PJSUA_ICE_CONFIG_USE_CUSTOM`
-      - set :cpp:any:`pjsua_acc_config::ice_cfg::ice_opt::trickle` to :cpp:any:`PJ_ICE_SESS_TRICKLE_HALF` or :cpp:any:`PJ_ICE_SESS_TRICKLE_FULL`.
+Trickle ICE (:rfc:`8838`) lets candidates be conveyed as soon as they
+appear and connectivity checks start in parallel. The first
+"initial offer" carries whatever is already known (typically just the
+host candidates) and later candidates are trickled to the peer via
+out-of-band signalling. In SIP that vehicle is SIP INFO messages with
+``application/trickle-ice-sdpfrag`` payloads, per :rfc:`8840`.
 
-For app using PJSUA2
-~~~~~~~~~~~~~~~~~~~~~~~~
- #. Enable and configure ICE as usual.
- #. Configure trickle ICE, it can only be configured per account basis:
+The win is measurable for calls that include a relayed (TURN)
+candidate, where the allocation handshake otherwise dominates setup
+latency — call ringing can start before TURN has finished allocating.
 
-    - set :cpp:any:`pj::AccountConfig::natConfig::iceTrickle` to :cpp:any:`PJ_ICE_SESS_TRICKLE_HALF` or :cpp:any:`PJ_ICE_SESS_TRICKLE_FULL`.
+For non-trickled ICE setup latency, see :doc:`standalone_ice` (the
+*Negotiation time* section).
 
-For pjsua app
-~~~~~~~~~~~~~~~~~~~~~~~~
- #. Enable and configure ICE as usual, e.g: ``--use-ice``, STUN & TURN settings.
- #. Add pjsua param ``--ice-trickle=N``, note: N=0:disabled, 1:half, 2:full.
+
+Half trickle vs full trickle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Trickle ICE has two operating modes, defined in
+:cpp:any:`pj_ice_sess_trickle`:
+
+:cpp:any:`PJ_ICE_SESS_TRICKLE_HALF`
+   Interoperable mode for when peer support is unknown at session
+   start. As initiator, all local candidates are gathered before
+   sending the initial offer (i.e. behaves like regular ICE on the
+   wire) but the offer advertises trickle support so the answerer may
+   trickle its side. As answerer, the agent trickles only when the
+   offer indicates trickle support; otherwise it falls back to regular
+   ICE.
+
+:cpp:any:`PJ_ICE_SESS_TRICKLE_FULL`
+   Use only when peer trickle support is known in advance. The
+   initiator sends an offer with whatever candidates are gathered so
+   far (commonly just host) and trickles the rest. PJSIP does not
+   probe peer capability — discovering it is the application's
+   responsibility.
+
+When in doubt, use **half**. Both modes still satisfy the regular ICE
+state machine.
+
+
+Aggressive nomination is disabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Trickle ICE and aggressive nomination are mutually exclusive
+(:cpp:any:`pj_ice_sess_options::aggressive` doxygen). Enabling
+``trickle`` automatically disables aggressive nomination —
+regular (controlled) nomination is used instead. The pjsua CLI does
+this for you when ``--ice-trickle`` is set; for PJSUA / PJSUA2
+applications setting ``iceTrickle`` is sufficient and no extra step
+is required.
+
+
+Enabling Trickle ICE
+--------------------
+
+ICE itself must already be enabled — trickle is a mode of ICE, not a
+standalone feature. The relevant switch lives on the account NAT
+configuration.
+
+PJSUA2
+~~~~~~
+
+Set :cpp:any:`pj::AccountNatConfig::iceTrickle` on the account
+configuration before the account is created or modified:
+
+.. code-block:: c++
+
+   AccountConfig acfg;
+   // ... existing config (id, server, credentials, etc.) ...
+   acfg.natConfig.iceEnabled  = true;
+   acfg.natConfig.iceTrickle  = PJ_ICE_SESS_TRICKLE_HALF;
+
+   try {
+       account.create(acfg);   // or account.modify(acfg);
+   } catch(Error& err) {
+   }
+
+The field defaults to :cpp:any:`PJ_ICE_SESS_TRICKLE_DISABLED`.
+
+PJSUA-LIB
+~~~~~~~~~
+
+Trickle can be configured globally (default for all accounts) or
+overridden per account.
+
+Globally — set the ``trickle`` field of
+:cpp:any:`pjsua_media_config::ice_opt` (an instance of
+:cpp:any:`pj_ice_sess_options`) on the media configuration passed
+to :cpp:any:`pjsua_init()`:
+
+.. code-block:: c
+
+    pjsua_media_config med_cfg;
+    pjsua_media_config_default(&med_cfg);
+    med_cfg.enable_ice   = PJ_TRUE;
+    med_cfg.ice_opt.trickle = PJ_ICE_SESS_TRICKLE_HALF;
+
+    pjsua_init(NULL, NULL, &med_cfg);
+
+Per account — opt out of the global ICE config and set the field
+explicitly:
+
+.. code-block:: c
+
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_config_default(&acc_cfg);
+    // ... id, registration URI, credentials, etc. ...
+    acc_cfg.ice_cfg_use = PJSUA_ICE_CONFIG_USE_CUSTOM;
+    acc_cfg.ice_cfg.enable_ice         = PJ_TRUE;
+    acc_cfg.ice_cfg.ice_opt.trickle    = PJ_ICE_SESS_TRICKLE_FULL;
+
+pjsua CLI
+~~~~~~~~~
+
+Add ``--ice-trickle=N`` where ``N`` is ``0`` (disabled), ``1`` (half),
+or ``2`` (full):
+
+.. code-block:: shell
+
+    $ ./pjsua --use-ice --ice-trickle=1 \
+              --stun-srv stun.example.org \
+              --turn-srv turn.example.org \
+              --turn-user [user] --turn-passwd ***
+
+Aggressive nomination is automatically disabled when
+``--ice-trickle`` is non-zero.
+
+
+How candidates are conveyed
+---------------------------
+
+The initial offer
+~~~~~~~~~~~~~~~~~
+
+When trickle is enabled, the SDP carried in the initial offer/answer
+contains:
+
+- ``a=ice-options:trickle`` — signals trickle support to the peer
+- ``a=ice-ufrag:`` / ``a=ice-pwd:`` — credentials
+- whatever ``a=candidate:`` lines are already gathered (in full
+  trickle mode this is often only the host candidates)
+- ``a=end-of-candidates`` — present only when local gathering has
+  already finished (half trickle initiator)
+- ``a=mid:`` — media identifier; required by :rfc:`8840` because
+  SDP fragments carried later in SIP INFO need to be associated
+  with a specific m-line
+
+PJSIP also adds ``trickle-ice`` to the ``Supported`` SIP header
+(see :sourcedir:`pjsip/src/pjsua-lib/pjsua_call.c` — the
+``str_trickle_ice`` literal).
+
+Subsequent candidates: SIP INFO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Late-arriving candidates (STUN srflx after the STUN response, TURN
+relay after the allocation completes) are encoded as an SDP fragment
+and sent in a SIP INFO message:
+
+.. code-block:: text
+
+   INFO sip:peer@example.com SIP/2.0
+   Content-Type: application/trickle-ice-sdpfrag
+   ...
+   <SDP fragment with new candidates, mid, ufrag, pwd>
+
+The fragment contains only the candidates added since the last
+conveyance (tracked internally via
+:cpp:any:`pjmedia_ice_trickle_has_new_cand`) plus the ``a=mid``,
+``a=ice-ufrag`` and ``a=ice-pwd`` lines and, when local gathering
+completes, the ``a=end-of-candidates`` marker.
+
+INFO messages are batched on a short timer
+(:c:macro:`PJSUA_TRICKLE_ICE_NEW_CAND_CHECK_INTERVAL`, default
+100 ms) so a burst of candidate-ready events produces one INFO, not
+several.
+
+Provisional responses (18x) before INFO
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the dialog is not yet established (i.e. before the final
+response) trickling on the answerer side rides 18x provisional
+responses with SDP. PJSIP retransmits these provisional responses
+(exponential backoff, capped at 6 attempts) until either the dialog
+is established (so SIP INFO becomes available) or trickling
+completes.
+
+
+Detecting peer trickle support
+------------------------------
+
+PJSIP doesn't actively probe peer capability before negotiation.
+Application-level discovery is done by inspecting the peer's:
+
+- ``Supported: trickle-ice`` header in initial signalling, or
+- ``a=ice-options:trickle`` attribute in a received SDP
+
+For greenfield endpoint-to-endpoint setups where peer support is
+guaranteed, full trickle is appropriate. For mixed fleets — or
+anything reaching PSTN, gateways, or legacy PBXs — start with half
+trickle.
+
+
+Programmatic candidate notifications
+------------------------------------
+
+Applications that want to observe candidate gathering progress (for
+UI feedback, logging, or custom signalling outside the PJSIP-managed
+SDP flow) can hook
+:cpp:any:`pjmedia_ice_cb::on_new_candidate` on the underlying
+PJMEDIA ICE transport, which forwards
+:cpp:any:`pj_ice_strans_cb::on_new_candidate` from PJNATH. The
+callback fires for each newly resolved srflx/relayed candidate and
+once more with ``end_of_cand=PJ_TRUE`` when gathering is complete.
+
+Most PJSIP applications don't need this — the PJSIP-LIB / PJSUA2
+SIP-side wiring delivers candidates automatically.
+
+
+Debugging
+---------
+
+A few markers help when call setup with trickle isn't working as
+expected:
+
+- **Initial SDP lacks** ``a=ice-options:trickle`` — trickle is
+  disabled or the global setting wasn't picked up. Verify
+  ``ice_cfg_use`` is ``PJSUA_ICE_CONFIG_USE_CUSTOM`` if you set it
+  per account.
+
+- **Peer ignores trickled INFO** — check the peer accepts
+  ``application/trickle-ice-sdpfrag`` and observes the
+  ``trickle-ice`` ``Supported`` header. Some intermediaries strip
+  unknown ``Supported`` values.
+
+- **No** ``a=end-of-candidates`` **ever sent** — gathering is hanging
+  on a STUN or TURN server. Check the server is reachable; the
+  ICE log at level 4 prints per-candidate progress (look for
+  ``Trickle`` and ``ice trickle`` lines in
+  :sourcedir:`pjsip/src/pjsua-lib/pjsua_call.c`).
+
+- **Aggressive nomination warnings** — harmless once trickle is on,
+  but they indicate the previously-set aggressive flag was
+  overridden by trickle (expected behaviour).
+
+
+Interaction with other ICE features
+-----------------------------------
+
+- **TURN TCP/TLS** — orthogonal. Trickle controls *when* candidates
+  are conveyed; the TURN connection type controls *what* relayed
+  candidate is allocated. See :doc:`turn_tcp_tls`.
+
+- **Manual host candidates** — manual candidates are added during
+  ICE initialisation alongside auto-detected ones, so they appear in
+  the initial offer with the auto-detected hosts. Trickle only
+  affects the srflx/relayed candidates that arrive later. See
+  :doc:`manual_ice_host_cand`.
+
+- **Negotiation timeout** — even with trickle, ICE will report
+  failure (with default settings) after roughly 7–8 seconds of no
+  successful pair, the same as regular ICE.
+
+
+PJSUA-LIB equivalents
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - PJSUA2
+     - PJSUA-LIB
+   * - :cpp:any:`pj::AccountNatConfig::iceTrickle`
+     - ``acc_cfg.ice_cfg.ice_opt.trickle`` (per account, with
+       ``ice_cfg_use = PJSUA_ICE_CONFIG_USE_CUSTOM``) or
+       ``med_cfg.ice_opt.trickle`` (global). The field type is
+       :cpp:any:`pj_ice_sess_options` and the relevant member is
+       :cpp:any:`pj_ice_sess_options::trickle`.
+
+Note: candidate trickling (SDP-fragment encoding, SIP INFO send/receive,
+checklist updates) is handled by PJSUA-LIB itself in
+:sourcedir:`pjsip/src/pjsua-lib/pjsua_call.c`; neither PJSUA-LIB nor
+PJSUA2 surfaces a per-candidate event. Applications needing that
+signal use the PJMEDIA-level callback
+:cpp:any:`pjmedia_ice_cb::on_new_candidate` (which itself wraps
+:cpp:any:`pj_ice_strans_cb::on_new_candidate` from PJNATH).
+The underlying trickle helpers —
+:cpp:any:`pjmedia_ice_trickle_update`,
+:cpp:any:`pjmedia_ice_trickle_encode_sdp`,
+:cpp:any:`pjmedia_ice_trickle_decode_sdp`,
+:cpp:any:`pj_ice_strans_update_check_list` — are PJMEDIA / PJNATH
+APIs intended for the SIP integration layer, not for direct
+application use.
+
 
 References
------------------
- - Trickle ICE: :rfc:`8838`
- - SIP usage for Trickle ICE: :rfc:`8840`
- 
+----------
+
+- Trickle ICE: :rfc:`8838`
+- SIP usage for Trickle ICE: :rfc:`8840`
+- Base ICE (for context): :rfc:`8445`
+- Initial implementation: :pr:`2588`; follow-up: :pr:`2667`

--- a/docs/source/specific-guides/network_nat/turn_tcp_tls.rst
+++ b/docs/source/specific-guides/network_nat/turn_tcp_tls.rst
@@ -1,0 +1,284 @@
+.. _guide_turn_tcp_tls:
+
+TURN over TCP and TLS
+=====================
+
+.. contents:: Table of Contents
+    :depth: 2
+
+.. tip::
+
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
+
+Overview
+--------
+
+By default a TURN client reaches the TURN server over UDP and the
+allocated relay also runs over UDP (:rfc:`5766`, updated by
+:rfc:`8656`). On networks that block outbound UDP — restrictive
+corporate firewalls, some hotel/airport networks, certain mobile
+carriers — the TURN allocation never completes and TURN candidates
+are unavailable. The remedy is to reach the TURN server over TCP
+or TLS instead. Connection-oriented transports traverse most
+firewalls that block UDP outright, and TLS additionally encrypts
+the client-server leg.
+
+PJSIP supports all three client-server transports via the
+:cpp:any:`pj_turn_tp_type` enum:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - ``pj_turn_tp_type`` value
+     - Client-to-server transport
+   * - ``PJ_TURN_TP_UDP``
+     - UDP datagrams (default; lowest latency)
+   * - ``PJ_TURN_TP_TCP``
+     - TCP connection
+   * - ``PJ_TURN_TP_TLS``
+     - TLS over TCP
+
+All three are part of base TURN (:rfc:`5766` / :rfc:`8656`). The
+same enum is reused for the *allocation* transport requested from
+the server, but ``PJ_TURN_TP_TLS`` is only valid as a client-server
+transport, never as an allocation transport — see *Allocations vs
+the data path* below.
+
+Client-server TCP and TLS support is long-standing in PJNATH
+(the TURN integration originally landed via ticket #485 and TURN
+TLS via :pr:`1017`). :pr:`2754` is a separate, later addition that
+implements RFC 6062 *TCP allocations*, i.e. TCP between the TURN
+server and a peer — useful for application protocols that need a
+reliable byte stream end-to-end. SIP media does not use this.
+
+
+Choosing a connection type
+--------------------------
+
+- **UDP** — start here. Lowest latency, fewest moving parts. Use unless
+  you have evidence UDP is being blocked.
+- **TCP** — fall back when UDP is dropped. Slightly higher latency
+  (head-of-line blocking when the network is lossy) but reliable
+  through almost every firewall.
+- **TLS** — use when network policy specifically requires encrypted
+  traffic to leave the network (e.g. corporate compliance, DPI
+  bypass), or when the TURN server only exposes a TLS listener on
+  port 5349.
+
+Some deployments configure two account-level TURN entries — one UDP
+primary, one TLS backup on a different port — and let the application
+decide which to use based on local probing. PJSIP itself does not do
+automatic UDP→TCP→TLS fallback; the application picks one.
+
+
+PJSUA2 — TURN over UDP or TCP
+-----------------------------
+
+Set :cpp:any:`pj::AccountNatConfig::turnConnType` to one of
+``PJ_TURN_TP_UDP`` or ``PJ_TURN_TP_TCP``:
+
+.. code-block:: c++
+
+   AccountConfig acfg;
+   // ... existing config ...
+   acfg.natConfig.iceEnabled    = true;
+   acfg.natConfig.turnEnabled   = true;
+   acfg.natConfig.turnServer    = "turn.example.com:3478";
+   acfg.natConfig.turnConnType  = PJ_TURN_TP_TCP;
+   acfg.natConfig.turnUserName  = "user";
+   acfg.natConfig.turnPassword  = "secret";
+
+   try {
+       account.create(acfg);
+   } catch(Error& err) {
+   }
+
+.. warning::
+
+   The PJSUA2 ``AccountNatConfig`` does not currently surface the TURN
+   TLS settings struct (:cpp:any:`pj_turn_sock_tls_cfg`). The doxygen
+   on :cpp:any:`pj::AccountNatConfig::turnConnType` lists only
+   ``PJ_TURN_TP_UDP`` and ``PJ_TURN_TP_TCP``. Setting ``turnConnType``
+   to ``PJ_TURN_TP_TLS`` in PJSUA2 will attempt a TLS connection, but
+   with the TLS configuration left at its zero-initialised default
+   the verification behaviour is whatever the SSL backend defaults
+   to — typically no CA verification, which is insecure. To configure
+   TURN TLS properly — CA file, client cert, ciphers — drop down to
+   the PJSUA-LIB :cpp:any:`pjsua_turn_config` struct (next section).
+
+
+PJSUA-LIB — TURN over UDP, TCP, or TLS
+--------------------------------------
+
+The PJSUA-LIB :cpp:any:`pjsua_turn_config` struct exposes the full
+TURN configuration including TLS:
+
+.. code-block:: c
+
+    pjsua_acc_config acc_cfg;
+    pjsua_acc_config_default(&acc_cfg);
+
+    acc_cfg.turn_cfg_use = PJSUA_TURN_CONFIG_USE_CUSTOM;
+
+    pjsua_turn_config *t = &acc_cfg.turn_cfg;
+    t->enable_turn   = PJ_TRUE;
+    t->turn_server   = pj_str("turn.example.com:5349");
+    t->turn_conn_type = PJ_TURN_TP_TLS;
+
+    t->turn_auth_cred.type = PJ_STUN_AUTH_CRED_STATIC;
+    t->turn_auth_cred.data.static_cred.username    = pj_str("user");
+    t->turn_auth_cred.data.static_cred.data_type   = PJ_STUN_PASSWD_PLAIN;
+    t->turn_auth_cred.data.static_cred.data        = pj_str("secret");
+    t->turn_auth_cred.data.static_cred.realm       = pj_str("example.com");
+
+    /* TLS-specific bits — only applicable when turn_conn_type is TLS */
+    t->turn_tls_setting.ca_list_file = pj_str("/etc/ssl/certs/turn-ca.pem");
+    t->turn_tls_setting.cert_file    = pj_str("/etc/pjsip/turn-client.pem");
+    t->turn_tls_setting.privkey_file = pj_str("/etc/pjsip/turn-client.key");
+
+    pjsua_acc_id acc_id;
+    pjsua_acc_add(&acc_cfg, PJ_TRUE, &acc_id);
+
+For the global default (applied to accounts that keep
+``turn_cfg_use = PJSUA_TURN_CONFIG_USE_DEFAULT``) the same fields
+exist on :cpp:any:`pjsua_media_config` directly (``enable_turn``,
+``turn_server``, ``turn_conn_type``, ``turn_auth_cred``,
+``turn_tls_setting``).
+
+The :cpp:any:`pj_turn_sock_tls_cfg` struct in
+:sourcedir:`pjnath/include/pjnath/turn_sock.h` includes additional
+fields:
+
+- ``ca_buf`` / ``cert_buf`` / ``privkey_buf`` — for in-memory
+  credentials instead of file paths (useful on platforms without a
+  writable filesystem)
+- ``cert_lookup`` / ``cert_direct`` — backend-specific options
+  (Windows Schannel certificate store; OpenSSL direct credentials)
+- ``password`` — passphrase for an encrypted private key
+- ``ssock_param`` — full :cpp:any:`pj_ssl_sock_param` (protocols,
+  ciphers, ECDH curves, signature algorithms, renegotiation,
+  socket options, timeout). Default protocol is
+  :c:macro:`PJ_TURN_TLS_DEFAULT_PROTO` (TLS 1.0 + 1.1 + 1.2).
+
+
+pjsua CLI
+~~~~~~~~~
+
+The pjsua sample app exposes the full set:
+
+.. code-block:: shell
+
+    $ ./pjsua --use-ice --use-turn \
+              --turn-srv turn.example.com:5349 \
+              --turn-tls \
+              --turn-tls-ca-file /etc/ssl/certs/turn-ca.pem \
+              --turn-tls-cert-file /etc/pjsip/turn-client.pem \
+              --turn-tls-privkey-file /etc/pjsip/turn-client.key \
+              --turn-user user --turn-passwd secret
+
+Relevant flags:
+
+- ``--turn-srv NAME:PORT`` — TURN server (mandatory)
+- ``--turn-tcp`` — use TCP connection to TURN
+- ``--turn-tls`` — use TLS connection to TURN
+- ``--turn-tls-ca-file`` — CA bundle for server verification
+- ``--turn-tls-cert-file`` / ``--turn-tls-privkey-file`` /
+  ``--turn-tls-privkey-pwd`` — client cert (when mutual TLS is
+  required)
+- ``--turn-tls-cipher`` — preferred cipher list
+- ``--turn-tls-neg-timeout`` — TLS handshake timeout
+
+Without ``--turn-tcp`` or ``--turn-tls`` the default is UDP.
+
+
+Allocations vs the data path
+----------------------------
+
+TURN has two layers of transport:
+
+1. **Client-to-server (control + data tunnel)** — set by
+   ``turn_conn_type``. Carries TURN messages and (via channel data /
+   Send indications) the media itself.
+2. **Server-to-peer (the actual relayed media)** — set by
+   :cpp:any:`pj_turn_alloc_param::peer_conn_type`. UDP by default.
+
+For typical SIP-over-ICE applications, leaving ``peer_conn_type`` at
+its UDP default is correct — the peer reaches the relay over UDP
+even if you reach the server over TCP/TLS. RFC 6062 TCP allocations
+(where the peer-side transport is also TCP) require an extra
+:cpp:any:`pj_turn_sock_connect()` call per peer and are rarely useful
+in SIP/SDP media; they are intended for application-specific
+protocols that need reliable byte streams.
+
+.. note::
+
+   PJSIP does not surface the TURN allocation's
+   ``peer_conn_type`` through :cpp:any:`pjsua_turn_config` —
+   PJSUA-LIB and PJSUA2 always allocate a UDP relay regardless of
+   ``turn_conn_type``. Standalone PJNATH applications can set
+   :cpp:any:`pj_turn_alloc_param::peer_conn_type` when needed.
+
+
+Defaults and ports
+------------------
+
+- **Default UDP/TCP port** — 3478 (IANA-registered)
+- **Default TLS port** — 5349 (IANA-registered)
+- :c:macro:`PJ_TURN_KEEP_ALIVE_SEC` — 15 s (TURN keep-alive interval)
+- :c:macro:`PJ_TURN_PERM_TIMEOUT` — 300 s (permission timeout)
+- :c:macro:`PJ_TURN_CHANNEL_TIMEOUT` — 600 s (channel binding lifetime)
+- :c:macro:`PJ_TURN_SSL_SOCK_DEFAULT_TIMEOUT` — 10 s (TLS handshake)
+
+These are compile-time settings, overridable in
+``pjlib/include/pj/config_site.h``.
+
+
+Interaction with ICE
+--------------------
+
+The TURN connection type only affects how the relayed candidate is
+*allocated*. Once the allocation succeeds, the relayed candidate is
+just another entry in the ICE candidate list and pairs against the
+peer's candidates by normal ICE rules. Whether ICE picks the relayed
+candidate or some other (cheaper) candidate depends on the
+connectivity-check outcome — TURN is the path of last resort.
+
+Trickle ICE (:doc:`trickle_ice`) and TURN TCP/TLS combine well — the
+TURN allocation handshake is the largest single source of pre-trickle
+ICE setup latency, so the speedup from trickling is most visible on
+calls that actually use the relayed candidate.
+
+
+PJSUA-LIB equivalents
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - PJSUA2
+     - PJSUA-LIB
+   * - :cpp:any:`pj::AccountNatConfig::turnEnabled`
+     - :cpp:any:`pjsua_turn_config::enable_turn`
+   * - :cpp:any:`pj::AccountNatConfig::turnServer`
+     - :cpp:any:`pjsua_turn_config::turn_server`
+   * - :cpp:any:`pj::AccountNatConfig::turnConnType` (UDP/TCP only)
+     - :cpp:any:`pjsua_turn_config::turn_conn_type` (UDP/TCP/TLS)
+   * - :cpp:any:`pj::AccountNatConfig::turnUserName` /
+       ``turnPassword`` / ``turnPasswordType``
+     - :cpp:any:`pjsua_turn_config::turn_auth_cred`
+   * - *(not exposed)*
+     - :cpp:any:`pjsua_turn_config::turn_tls_setting`
+       (:cpp:any:`pj_turn_sock_tls_cfg`)
+
+
+References
+----------
+
+- TURN (UDP relays): :rfc:`5766`
+- TURN TCP Allocations: :rfc:`6062`
+- TURN TCP implementation: :pr:`2754`
+- ICE: :rfc:`8445`


### PR DESCRIPTION
## Summary

Three new/expanded guides under `specific-guides/network_nat/` to fill long-standing ICE/TURN documentation gaps.

- **`trickle_ice.rst`** — rewrites the minimal "how to enable" stub into a practical guide: half vs full modes, aggressive-nomination interaction, SDP conveyance (`a=ice-options:trickle` / `a=end-of-candidates` / `a=mid`), SIP INFO with `application/trickle-ice-sdpfrag` (RFC 8840) and the 18x retransmit path used before dialog establishment, peer-support detection, debugging markers.
- **`manual_ice_host_cand.rst`** — new guide for #4618 (PJSIP 2.17): motivates Docker / container / multi-homed / split-tunnel-VPN cases, documents the additive + address-family-filtered + port-from-base semantics, both PJSUA2 (`SocketAddressVector`) and PJSUA-LIB (`pj_sockaddr[]`) APIs, and the per-account-only scope (no `pjsua_media_config` equivalent).
- **`turn_tcp_tls.rst`** — new guide for the client-server TCP / TLS TURN transports: `pj_turn_tp_type` enum, choosing UDP vs TCP vs TLS, PJSUA2 vs PJSUA-LIB exposure (PJSUA2 currently does not surface `pj_turn_sock_tls_cfg`; warning + drop-down example), full pjsua CLI flag set, and the client-server vs server-peer (RFC 6062 / #2754) transport distinction.

Submodule bump: `docs/source/pjproject` 2.16 → post-2.17 master (`d85c5cdd6`) so #4618 (manual host candidates) is in scope.

Convention follows `realtime_text.rst` / `customizing_messages.rst`: PJSUA2 prose first with a PJSUA-LIB-equivalents table at the bottom. Tables are `list-table` for resilience.

## Test plan

- [x] Local `sphinx-build -b html` — clean; zero warnings in the three new/changed files
- [x] All `:cpp:any:` references resolve as links (verified in rendered HTML)
- [x] Tables render with correct row counts (1 in `trickle_ice`, 1 in `manual_ice_host_cand`, 2 in `turn_tcp_tls`)
- [x] Code-claim audit against `pjproject` headers (PJNATH, PJMEDIA, PJSUA-LIB, PJSUA2, pjsua CLI) before writing
- [x] Self-review pass for accuracy: corrected PR-vs-version attribution (#2754 is server-peer RFC 6062, not client-server), wrong claim that `pjsua_media_config` exposes `ice_manual_host`, "Pre-2.16" vs "Pre-2.17" wording, and the chained-role `::cpp:any:` syntax that rendered awkwardly
- [ ] Reviewer to check RTD preview for table rendering and cross-link resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>