### PR TITLE
docs: ip_change.rst — expand for newer options and mobile tuning

### DIFF
--- a/docs/source/specific-guides/network_nat/ip_change.rst
+++ b/docs/source/specific-guides/network_nat/ip_change.rst
@@ -1,102 +1,371 @@
+.. _guide_ip_change:
+
 Handling IP address change
 =========================================
 
 .. contents:: Table of Contents
     :depth: 2
 
+.. tip::
 
-This article describes some issues and their corresponding solutions related to access point disconnection, reconnection, IP address change, and how to handle these events in your PJSIP applications, specifically 
-for PJSIP version 2.7 or later. This wiki will focus on the new API :cpp:any:`pjsua_handle_ip_change()`.
+   PJSUA-LIB readers — symbol equivalents are listed at the bottom of
+   this page.
+
+This article describes how to handle IP-address changes in PJSIP
+applications, with a focus on the mobile case (Wi-Fi / cellular
+hand-off, AP roaming, VPN connect/disconnect). It targets PJSIP 2.7
+and later, where the high-level API
+:cpp:func:`pj::Endpoint::handleIpChange` was introduced (PJSUA-LIB:
+:cpp:any:`pjsua_handle_ip_change`).
+
+PJSIP does **not** detect IP changes on its own; the application
+observes the change via platform APIs and then calls into PJSIP to
+have it clean up. Detection pointers are at the end of this page;
+the bulk of the article is about the cleanup.
 
 
 Problem description
 ----------------------
 
-IP address change and/or access point disconnection and reconnection are scenarios that need to be handled in mobile applications. Few issues or scenarios related to this for example are:
+IP-address change and access-point reconnection are common on mobile.
+Typical scenarios:
 
- - user moves outside the range of a Wi-Fi access point (AP) and lost the connection
- - user moves outside the range of one AP and reconnect to another
- - the handset may get new IP address if user reconnects to different AP
+- Wi-Fi disconnect → cellular fallback
+- Cellular → Wi-Fi when re-entering coverage
+- Wi-Fi → Wi-Fi between two APs with different subnets
+- VPN connect / disconnect
 
+In each case the local IP that PJSIP was using disappears or is
+replaced. Without intervention, this manifests as long send timeouts,
+stale registrations, and dropped calls — particularly painful when
+TCP/TLS transports are involved, because lingering connections bound
+to the dead interface can wedge the SIP path for tens of seconds
+before the OS gives up.
 
-API: *pjsua_handle_ip_change()*
-------------------------------------------------------------------
-Since 2.7, pjsua API introduce a new API (:cpp:func:`pjsua_handle_ip_change()`) to handle IP address change. This way, application only needs to detect for IP address change event, and let the library
-handle the IP address change based on the configuration. 
+:cpp:func:`pj::Endpoint::handleIpChange` (PJSUA-LIB:
+:cpp:any:`pjsua_handle_ip_change`) lets the application announce
+"my IP changed; clean up" and have the library do the work
+(transport restart, optional shutdown of stale transports, account
+re-registration, optional re-INVITE / UPDATE on active calls). The
+application is still responsible for **detecting** the change
+(platform-specific, see below).
 
+.. important::
 
-
-*pjsua_handle_ip_change()* flow
---------------------------------------------
-When invoked, the stack will:
-
-1. Restart the SIP transport listener
-
-   This will restart TCP/TLS listener no matter whether they are enabled or not when the transport were created. If you don't have any use of the listener, you can disable this.
-   However, if you do need this, then on some platform (e.g: on iOS), some delay is needed when restarting the listener.
-
-   ref: :cpp:any:`pjsua_ip_change_param::restart_listener` and :cpp:any:`pjsua_ip_change_param::restart_lis_delay`.
-
-2. Shutdown the SIP transport used by account registration
-
-   On some platform (e.g: iOS), it is necessary to shutdown the transport used by registration, since presumably the socket is already in a bad state.
-
-   ref: ``ip_change_cfg.shutdown_tp`` in :cpp:class:`pjsua_acc_config`.
-
-3. Update contact URI by sending re-Registration
-
-   The server needs to be updated of the new Contact URI when the IP address changed. Set it to PJ_TRUE to allow the stack update contact URI to the server.
-
-   ref: :cpp:member:`pjsua_acc_config::allow_contact_rewrite` and :cpp:member:`pjsua_acc_config::contact_rewrite_method`.
-
-4. Hangup active calls or continue the call by sending re-INVITE
-
-   You can either hangup or maintain the ongoing/active calls. If you intend to maintain the active calls, updating dialog's contact URI is required. This can be done by specifying :cpp:any:`PJSUA_CALL_UPDATE_CONTACT` to the reinvite flags. Note that, hanging up calls might be inevitable on some cases, please see
-   **Network change to the same IP address type. (IPv4 to IPv4) or (IPv6 to IPv6)** section below.
-
-   ref: :cpp:any:`pjsua_ip_change_acc_cfg::hangup_calls` and :cpp:any:`pjsua_ip_change_acc_cfg::reinvite_flags` in :cpp:class:`pjsua_acc_config::ip_change_cfg`
+   Call ``handleIpChange`` **after the new network connection is
+   established and a usable IP is available**, not at the moment the
+   old interface goes down. Listener restart, transport reopen, and
+   re-REGISTER all need the new stack to be up — calling too early
+   means the steps fail and have to be retried by the application.
+   On a Wi-Fi-off → cellular-on transition, wait for the platform's
+   "default network changed / reachable" event before invoking.
 
 
-Notes and limitations
-----------------------
-To monitor the progress of IP change handling, application can use :cpp:member:`pjsua_callback::on_ip_change_progress` callback. The callback will notify application of these events:
+High-level flow
+---------------
 
-- SIP transport listener restart,
-- SIP transport shutdown,
-- contact update (re-registration process), and
-- calls hangup or retry (re-INVITE).
+When :cpp:func:`pj::Endpoint::handleIpChange` is invoked, PJSUA-LIB
+runs the following in order. Parameters live on
+:cpp:any:`pj::IpChangeParam` (global) and
+:cpp:any:`pj::AccountIpChangeConfig` (per-account, on
+``AccountConfig::ipChangeConfig``).
 
-Related to maintaining a call during IP change, there are some scenarios that are currently not implemented by IP change mechanism, so application needs to handle manually: If IP change occurs during SDP negotiation (and it is not completed yet, so there cannot be another SDP offer), updating such call needs to be done in two steps:
+1. **Shut down all TCP/TLS transports** (if
+   :cpp:any:`pj::IpChangeParam::shutdownTransport` is set).
+   This is the key step for mobile responsiveness — sockets still
+   alive on the old interface won't sit waiting for a remote FIN
+   while the OS retransmits over a dead path. Added in :pr:`3781`,
+   default ``true``. UDP is *not* covered here; UDP "transports"
+   are the listener itself, handled by the next step.
 
-#. Update Contact header, so remote endpoint can send its SDP answer to our new contact address, i.e: use UPDATE without SDP offer (:cpp:any:`PJSUA_CALL_NO_SDP_OFFER` flag). Note that, not every endpoint supports UPDATE. Contact is used by remote to resolve target before sending new requests. If proxy is used, then you can probably skip this.
-#. Update local media transport after SDP answer is received, by sending UPDATE/re-INVITE with :cpp:any:`PJSUA_CALL_REINIT_MEDIA` flag.
+2. **Restart the SIP transport listener** (if
+   :cpp:any:`pj::IpChangeParam::restartListener` is set, the
+   default). This rebinds the listening socket so it picks up the
+   new IP. See :ref:`listener_restart_caveats` below.
 
-If IP change occurs before a call is confirmed:
- - For outgoing call, the call will be disconnected and reported to application via :cpp:any:`pjsua_callback::on_call_state`.
- - For incoming call however, it will continue to be active. Application can manually hangup the call if desired.
+3. **Per account: shut down the registration transport** (if
+   :cpp:any:`pj::AccountIpChangeConfig::shutdownTp` is set on the
+   account, default ``true``). Even if the account shares its
+   transport with another, the transport is force-closed — required
+   on platforms where the kernel doesn't deliver disconnect
+   notifications promptly (iOS in particular).
 
-IP change scenarios
-----------------------
+4. **Re-register**: send REGISTER with the new Contact URI, per
+   :cpp:any:`pj::AccountNatConfig::contactRewriteUse` /
+   :cpp:any:`pj::AccountNatConfig::contactRewriteMethod`.
 
-Network change to the same IP address type. (IPv4 to IPv4) or (IPv6 to IPv6)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5. **Active calls**: either hang up
+   (:cpp:any:`pj::AccountIpChangeConfig::hangupCalls`) or refresh
+   them with re-INVITE or SIP UPDATE
+   (:cpp:any:`pj::AccountIpChangeConfig::reinviteFlags`,
+   :cpp:any:`pj::AccountIpChangeConfig::reinvUseUpdate`). When
+   ``reinviteFlags`` is 0, neither is sent.
 
-Update contact process (re-Registration) and call handling (hang-up or continue the call) should be handled by the API (:cpp:func:`pjsua_handle_ip_change()`) without any special treatment from the application. 
 
-Network change to a different IP address type. (IPv4 to IPv6) or (IPv6 to IPv4)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Tuning for fast switching (mobile)
+----------------------------------
 
-IPv6 needs specific account configuration — see
+On a mobile hand-off, the total time between "old IP gone" and
+"calls flowing on the new IP" is dominated by three things:
+
+- **Stale TCP/TLS sockets on the old interface.** A REGISTER or
+  in-dialog request that lands on a still-open connection bound to
+  the now-dead interface will queue / retransmit until the OS gives
+  up — typically tens of seconds. Set
+  :cpp:any:`pj::IpChangeParam::shutdownTransport` to ``true`` (the
+  default since :pr:`3781`) to force-close all TCP/TLS transports
+  immediately.
+
+- **Stale UDP listener bound to the old IP.** If you created the
+  UDP transport with a specific bound address (a literal IP rather
+  than ``0.0.0.0`` / ``::``), the socket can't receive on the new
+  IP. :cpp:any:`pj::IpChangeParam::restartListener` rebinds the
+  listener — but as a side-effect it **resets the bound address to
+  wildcard** (see :ref:`listener_restart_caveats`).
+
+- **REGISTER on a dead transport.** If your application calls
+  :cpp:func:`pj::Account::modify` during IP change to update
+  account config (IPv6 preference, etc.), the default behaviour is
+  to fire a REGISTER immediately — on the *old* transport, which is
+  dead. Set
+  :cpp:any:`pj::AccountRegConfig::disableRegOnModify` to ``true``
+  (added in :pr:`3910`) to suppress that, then let
+  :cpp:func:`pj::Endpoint::handleIpChange` drive the re-REGISTER on
+  the new transport.
+
+For active calls, prefer **UPDATE** over re-INVITE when the peer
+supports it: set
+:cpp:any:`pj::AccountIpChangeConfig::reinvUseUpdate` to ``true``
+(added in :pr:`3146`). Both methods carry a new SDP offer / answer
+with the post-change addresses; the win of UPDATE (:rfc:`3311`) is
+that it's a generally lighter exchange than re-INVITE. PJSUA-LIB
+falls back to re-INVITE if the peer didn't advertise UPDATE in
+``Allow``.
+
+.. note::
+
+   **Do you need a TCP/TLS listener at all?** Mobile clients almost
+   never accept incoming SIP connections — they REGISTER and receive
+   on the same outbound connection. Two build-time macros in
+   ``config_site.h`` skip listener creation entirely (both default
+   ``0``):
+
+   - :c:macro:`PJSIP_TCP_TRANSPORT_DONT_CREATE_LISTENER`
+   - :c:macro:`PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER`
+
+   With listeners disabled, outbound TCP/TLS still works and the
+   listener-restart step on IP change is a graceful no-op (per
+   :pr:`3873`). See the macro doxygen for the additional
+   ``contact_use_src_port`` setting they require. To remove TLS code
+   entirely for footprint, set :c:macro:`PJSIP_HAS_TLS_TRANSPORT` to
+   ``0`` (TCP cannot be disabled at build time).
+
+A reasonable mobile-tuned configuration in PJSUA2:
+
+.. code-block:: c++
+
+    // Per-account knobs — set before account.create() / account.modify().
+    AccountConfig acc_cfg;
+    // ... existing config (id, registrar, credentials) ...
+    acc_cfg.regConfig.disableRegOnModify        = true;  // if you call modify()
+    acc_cfg.ipChangeConfig.shutdownTp           = true;  // default
+    acc_cfg.ipChangeConfig.reinvUseUpdate       = true;  // prefer UPDATE
+    acc->modify(acc_cfg);  // or set on AccountConfig before account.create()
+
+    // On the IP-change event, hand off to PJSUA-LIB:
+    IpChangeParam param;            // defaults: restartListener=true,
+                                    // shutdownTransport=true
+    Endpoint::instance().handleIpChange(param);
+
+PJSUA-LIB equivalent:
+
+.. code-block:: c
+
+    pjsua_ip_change_param ip_change_param;
+    pjsua_ip_change_param_default(&ip_change_param);
+    /* All three already default to PJ_TRUE; shown for clarity. */
+    ip_change_param.shutdown_transport = PJ_TRUE;
+    ip_change_param.restart_listener   = PJ_TRUE;
+
+    /* On the account config: */
+    acc_cfg.ip_change_cfg.shutdown_tp      = PJ_TRUE;
+    acc_cfg.ip_change_cfg.reinv_use_update = PJ_TRUE;  /* prefer UPDATE */
+    acc_cfg.disable_reg_on_modify          = PJ_TRUE;  /* if you call modify() */
+
+    pjsua_handle_ip_change(&ip_change_param);
+
+
+On ``bound_addr`` and OS routing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Binding a transport to a literal local IP via
+:cpp:any:`pj::TransportConfig::boundAddress` /
+:cpp:any:`pjsua_transport_config::bound_addr` indirectly pins the
+outbound interface — the kernel routes by destination but is
+constrained by the bound source, and each IP normally belongs to
+one interface. Two caveats matter on mobile:
+
+- If the bound IP no longer exists on any interface after the IP
+  change (the Wi-Fi case), the socket's sends fail with
+  ``EADDRNOTAVAIL``. If you set ``bound_addr`` explicitly, you're
+  responsible for updating it to the new IP **before** calling
+  ``handleIpChange``.
+- On Android, the per-app default network is enforced *above*
+  ``bind()`` — binding to a non-default-network IP isn't sufficient
+  on its own. Pair it with
+  ``ConnectivityManager.bindProcessToNetwork(newNetwork)`` (Java
+  side) so all subsequently-created sockets use that network.
+
+For most apps the simplest pattern is to leave ``bound_addr`` empty
+(wildcard) and let the kernel pick — that picks up route-table
+changes immediately. Set ``bound_addr`` only when you have a real
+need to pin to a specific interface.
+
+If you do need to pin, the field lives in two places — SIP transport
+and per-account media (RTP/RTCP):
+
+.. code-block:: c++
+
+   // PJSUA2 — call before recreating SIP transport / modifying account.
+   const std::string new_local_ip = "10.0.0.5";
+
+   // SIP transport: pass on the TransportConfig at transportCreate() time.
+   TransportConfig sip_tp_cfg;
+   sip_tp_cfg.boundAddress = new_local_ip;
+   ep.transportDestroy(old_sip_tp_id);
+   ep.transportCreate(PJSIP_TRANSPORT_UDP, sip_tp_cfg);
+
+   // Media (RTP/RTCP): on the account config, then re-apply.
+   acc_cfg.mediaConfig.transportConfig.boundAddress = new_local_ip;
+   acc->modify(acc_cfg);
+
+   ep.handleIpChange(IpChangeParam());
+
+.. code-block:: c
+
+   /* PJSUA-LIB */
+   pj_str_t new_local_ip = pj_str("10.0.0.5");
+
+   /* SIP transport: recreate with the new bound_addr. */
+   pjsua_transport_config tp_cfg;
+   pjsua_transport_config_default(&tp_cfg);
+   tp_cfg.bound_addr = new_local_ip;
+   pjsua_transport_close(old_sip_tp_id, PJ_TRUE);
+   pjsua_transport_create(PJSIP_TRANSPORT_UDP, &tp_cfg, NULL);
+
+   /* Media (RTP/RTCP) lives on the account's rtp_cfg. */
+   acc_cfg.rtp_cfg.bound_addr = new_local_ip;
+   pjsua_acc_modify(acc_id, &acc_cfg);
+
+   pjsua_ip_change_param param;
+   pjsua_ip_change_param_default(&param);
+   pjsua_handle_ip_change(&param);
+
+Note that an existing SIP transport can't have its ``bound_addr``
+changed in place; recreate the transport (close the old, create the
+new). The media ``rtp_cfg.bound_addr`` updated through
+``acc_modify`` / ``modify`` is picked up the next time a media
+transport is created — for new calls, and for existing calls that
+are refreshed with :c:macro:`PJSUA_CALL_REINIT_MEDIA` (which is part
+of the default ``reinviteFlags``, so ``handleIpChange`` itself
+triggers it).
+
+
+.. _listener_restart_caveats:
+
+Listener restart caveats
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two pieces of behaviour to be aware of when
+``restartListener = true``:
+
+- **Bound address is reset to wildcard.** If you originally created
+  the listener with a specific bound IP (via
+  :cpp:any:`pj::TransportConfig::boundAddress` /
+  :cpp:any:`pjsua_transport_config::bound_addr`), the restart in
+  :cpp:any:`pjsip_tcp_transport_restart` /
+  :cpp:any:`pjsip_tls_transport_restart` rebinds to ``0.0.0.0``
+  (IPv4) or ``::`` (IPv6). This is documented in :pr:`3873`. If
+  you require the listener to stay bound to a specific interface,
+  set ``restartListener = false`` and manage the listener yourself
+  after IP change.
+
+- **Restart can race the underlying socket.** Some platforms
+  (notably iOS) need a moment between "old socket released" and
+  "new socket can bind" — see
+  :cpp:any:`pj::IpChangeParam::restartLisDelay`
+  (default ``PJSUA_TRANSPORT_RESTART_DELAY_TIME``). If a restart
+  attempt returns any non-success status and ``restartLisDelay`` is
+  non-zero, PJSUA-LIB schedules one retry after the delay; the
+  per-attempt result is logged at level 3.
+
+
+Maintaining a call during IP change
+-----------------------------------
+
+By default, :cpp:func:`pj::Endpoint::handleIpChange` keeps active
+calls alive and refreshes them via re-INVITE (or UPDATE, see above)
+once re-registration completes. The refresh uses
+:cpp:any:`pj::AccountIpChangeConfig::reinviteFlags`, defaulting to
+:c:macro:`PJSUA_CALL_REINIT_MEDIA` |
+:c:macro:`PJSUA_CALL_UPDATE_CONTACT` |
+:c:macro:`PJSUA_CALL_UPDATE_VIA`.
+
+Two situations the automatic flow doesn't cover and the application
+must handle:
+
+- **IP change during ongoing SDP negotiation** (offer sent, answer
+  not yet received). A new SDP offer can't be sent. Do this in two
+  steps:
+
+  1. Update Contact only (no new offer) via UPDATE with
+     :c:macro:`PJSUA_CALL_NO_SDP_OFFER` so the peer can route its
+     pending answer to the new address. Not every endpoint
+     supports UPDATE — if a proxy is in the path you can usually
+     skip this step.
+  2. Update media after the answer arrives, via UPDATE / re-INVITE
+     with :c:macro:`PJSUA_CALL_REINIT_MEDIA`.
+
+- **IP change before a call is confirmed.** For *outgoing* calls
+  the call is disconnected and reported via
+  :cpp:func:`pj::Call::onCallState` (PJSUA-LIB:
+  :cpp:any:`pjsua_callback::on_call_state`). For *incoming* calls
+  the dialog stays active; hang up manually if the new IP makes
+  the call infeasible.
+
+
+Network change to a different IP version (IPv4 ↔ IPv6)
+------------------------------------------------------
+
+For same-family IP changes (IPv4 → IPv4 or IPv6 → IPv6) the call to
+:cpp:func:`pj::Endpoint::handleIpChange` is sufficient. For
+cross-family changes, the application has to set up a transport for
+the new family first and then update account preferences. See
 :ref:`IPv6 modes and defaults <ipv6_modes>` in the
 :doc:`IPv6 and NAT64 guide <ipv6>` for the mode reference.
-On the case of IP address type change, additional steps are required
-from the application:
 
-#. Once application detects a network with IP address type change, a new transport might need to be created.
+PJSUA2 (keep your own :cpp:any:`pj::AccountConfig` around since the
+class doesn't expose a getter):
 
-#. Once the transport is available, modify the account's IP version
-   preferences if necessary by calling :cpp:func:`pjsua_acc_modify()`,
-   and then call :cpp:func:`pjsua_handle_ip_change()`.
+.. code-block:: c++
+
+    void ip_change_to_ip6(Account *acc, AccountConfig &acc_cfg)
+    {
+        // Create new IPv6 transport if needed; e.g. TLS6
+        Endpoint &ep = Endpoint::instance();
+        TransportConfig tp_cfg;
+        ep.transportCreate(PJSIP_TRANSPORT_TLS6, tp_cfg);
+
+        acc_cfg.sipConfig.ipv6Use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+        acc_cfg.mediaConfig.ipv6Use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
+
+        // Prevent modify() from sending a REGISTER on the old transport.
+        acc_cfg.regConfig.disableRegOnModify = true;
+        acc->modify(acc_cfg);
+
+        IpChangeParam param;
+        ep.handleIpChange(param);
+    }
 
 PJSUA-LIB:
 
@@ -135,30 +404,7 @@ PJSUA-LIB:
         ...
         // Handle ip change
         pjsua_ip_change_param_default(&param);
-        pjsua_handle_ip_change(param);
-    }
-
-PJSUA2 (keep your own ``AccountConfig`` around since the class doesn't
-expose a getter):
-
-.. code-block:: c++
-
-    void ip_change_to_ip6(Account *acc, AccountConfig &acc_cfg)
-    {
-        // Create new IPv6 transport if needed; e.g. TLS6
-        Endpoint &ep = Endpoint::instance();
-        TransportConfig tp_cfg;
-        ep.transportCreate(PJSIP_TRANSPORT_TLS6, tp_cfg);
-
-        acc_cfg.sipConfig.ipv6Use   = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
-        acc_cfg.mediaConfig.ipv6Use = PJSUA_IPV6_ENABLED_USE_IPV6_ONLY;
-
-        // Prevent modify() from sending a REGISTER on the old transport.
-        acc_cfg.regConfig.disableRegOnModify = true;
-        acc->modify(acc_cfg);
-
-        IpChangeParam param;
-        ep.handleIpChange(param);
+        pjsua_handle_ip_change(&param);
     }
 
 .. note::
@@ -171,17 +417,107 @@ expose a getter):
    ``USE_IPV6_ONLY`` when the old family is truly gone.
 
 
+Diagnostics
+-----------
+
+Progress callback
+~~~~~~~~~~~~~~~~~
+
+:cpp:func:`pj::Endpoint::onIpChangeProgress` (PJSUA2) and the
+underlying :cpp:any:`pjsua_callback::on_ip_change_progress`
+(PJSUA-LIB) fire for each stage of the operation:
+
+- :c:macro:`PJSUA_IP_CHANGE_OP_RESTART_LIS` — listener restart
+- :c:macro:`PJSUA_IP_CHANGE_OP_ACC_SHUTDOWN_TP` — per-account
+  transport shutdown
+- :c:macro:`PJSUA_IP_CHANGE_OP_ACC_UPDATE_CONTACT` — re-REGISTER
+- :c:macro:`PJSUA_IP_CHANGE_OP_ACC_HANGUP_CALLS` — call hang-up
+- :c:macro:`PJSUA_IP_CHANGE_OP_ACC_REINVITE_CALLS` — call refresh
+  (re-INVITE / UPDATE)
+- :c:macro:`PJSUA_IP_CHANGE_OP_COMPLETED` — all stages done
+
+Each invocation carries a status code and per-stage info — use this
+for UI feedback or to time the overall switch.
+
+Log lines
+~~~~~~~~~
+
+At log level 3, ``pjsua_core.c`` emits ``"Start handling IP address
+change"`` on entry. At level 4 it logs the staged steps:
+
+- ``IP change shutting down transports..``
+- ``IP change temporarily ignores request timeout``
+- per-listener restart attempts (with the listener's name)
+
+The TCP/TLS listener restart helpers
+(:cpp:any:`pjsip_tcp_transport_restart` /
+:cpp:any:`pjsip_tls_transport_restart`) also log at level 3 when a
+restart is requested but no listener exists — that's the no-op
+"update published address only" path from :pr:`3873`.
+
 
 IP address change detection
 ----------------------------------
 
+PJSIP doesn't poll for IP changes; the application has to detect
+and call :cpp:func:`pj::Endpoint::handleIpChange` (PJSUA-LIB:
+:cpp:any:`pjsua_handle_ip_change`). Platform pointers:
+
 iOS
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Have a look at `Reachability API <https://developer.apple.com/library/content/samplecode/Reachability/Introduction/Intro.html>`__.
+~~~
+
+Use the `Reachability API
+<https://developer.apple.com/library/content/samplecode/Reachability/Introduction/Intro.html>`__
+or modern Network framework path monitor. Note that iOS aggressively
+suspends sockets when the app backgrounds — see also the iOS push
+notification guide if your app needs to wake on incoming SIP traffic.
 
 Android
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Have a look at `ConnectivityManager <https://developer.android.com/training/monitoring-device-state/connectivity-monitoring.html>`__.
+~~~~~~~
+
+Use `ConnectivityManager
+<https://developer.android.com/training/monitoring-device-state/connectivity-monitoring.html>`__
+with a ``NetworkCallback`` registered via
+``registerDefaultNetworkCallback`` (API 24+). On older API levels,
+``CONNECTIVITY_ACTION`` broadcast is the fallback.
 
 
+PJSUA-LIB equivalents
+---------------------
 
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - PJSUA2
+     - PJSUA-LIB
+   * - :cpp:any:`pj::IpChangeParam::restartListener`
+     - :cpp:any:`pjsua_ip_change_param::restart_listener`
+   * - :cpp:any:`pj::IpChangeParam::restartLisDelay`
+     - :cpp:any:`pjsua_ip_change_param::restart_lis_delay`
+   * - :cpp:any:`pj::IpChangeParam::shutdownTransport`
+     - :cpp:any:`pjsua_ip_change_param::shutdown_transport`
+   * - :cpp:func:`pj::Endpoint::handleIpChange`
+     - :cpp:any:`pjsua_handle_ip_change`
+   * - :cpp:func:`pj::Endpoint::onIpChangeProgress`
+     - :cpp:any:`pjsua_callback::on_ip_change_progress`
+   * - :cpp:any:`pj::AccountRegConfig::disableRegOnModify`
+     - :cpp:any:`pjsua_acc_config::disable_reg_on_modify`
+   * - :cpp:any:`pj::AccountIpChangeConfig::shutdownTp`
+     - :cpp:any:`pjsua_ip_change_acc_cfg::shutdown_tp`
+   * - :cpp:any:`pj::AccountIpChangeConfig::hangupCalls`
+     - :cpp:any:`pjsua_ip_change_acc_cfg::hangup_calls`
+   * - :cpp:any:`pj::AccountIpChangeConfig::reinviteFlags`
+     - :cpp:any:`pjsua_ip_change_acc_cfg::reinvite_flags`
+   * - :cpp:any:`pj::AccountIpChangeConfig::reinvUseUpdate`
+     - :cpp:any:`pjsua_ip_change_acc_cfg::reinv_use_update`
+
+
+References
+----------
+
+- Shutdown all TCP/TLS transports on IP change: :pr:`3781`
+- SIP UPDATE for refreshing calls: :pr:`3146`
+- Listener restart checks: :pr:`3872`
+- Listener restart: skip if no listener, doc bound-addr reset: :pr:`3873`
+- ``disable_reg_on_modify``: :pr:`3910`

--- a/docs/source/specific-guides/network_nat/ip_change.rst
+++ b/docs/source/specific-guides/network_nat/ip_change.rst
@@ -156,21 +156,24 @@ falls back to re-INVITE if the peer didn't advertise UPDATE in
    With listeners disabled, outbound TCP/TLS still works and the
    listener-restart step on IP change is a graceful no-op (per
    :pr:`3873`). See the macro doxygen for the additional
-   ``contact_use_src_port`` setting they require. To remove TLS code
-   entirely for footprint, set :c:macro:`PJSIP_HAS_TLS_TRANSPORT` to
-   ``0`` (TCP cannot be disabled at build time).
+   :cpp:any:`pjsua_acc_config::contact_use_src_port` /
+   :cpp:any:`pj::AccountNatConfig::contactUseSrcPort` setting they
+   require. To remove TLS code entirely for footprint, set
+   :c:macro:`PJSIP_HAS_TLS_TRANSPORT` to ``0`` (TCP cannot be
+   disabled at build time).
 
-A reasonable mobile-tuned configuration in PJSUA2:
+A reasonable mobile-tuned configuration in PJSUA2 (set the
+per-account knobs on the :cpp:any:`pj::AccountConfig` you pass to
+:cpp:func:`pj::Account::create` or :cpp:func:`pj::Account::modify`):
 
 .. code-block:: c++
 
-    // Per-account knobs — set before account.create() / account.modify().
     AccountConfig acc_cfg;
     // ... existing config (id, registrar, credentials) ...
-    acc_cfg.regConfig.disableRegOnModify        = true;  // if you call modify()
-    acc_cfg.ipChangeConfig.shutdownTp           = true;  // default
-    acc_cfg.ipChangeConfig.reinvUseUpdate       = true;  // prefer UPDATE
-    acc->modify(acc_cfg);  // or set on AccountConfig before account.create()
+    acc_cfg.regConfig.disableRegOnModify  = true;  // if you call modify()
+    acc_cfg.ipChangeConfig.shutdownTp     = true;  // default
+    acc_cfg.ipChangeConfig.reinvUseUpdate = true;  // prefer UPDATE
+    account.modify(acc_cfg);  // or pass acc_cfg to account.create()
 
     // On the IP-change event, hand off to PJSUA-LIB:
     IpChangeParam param;            // defaults: restartListener=true,
@@ -183,7 +186,8 @@ PJSUA-LIB equivalent:
 
     pjsua_ip_change_param ip_change_param;
     pjsua_ip_change_param_default(&ip_change_param);
-    /* All three already default to PJ_TRUE; shown for clarity. */
+    /* shutdown_transport and restart_listener already default to
+     * PJ_TRUE; shown here for clarity. */
     ip_change_param.shutdown_transport = PJ_TRUE;
     ip_change_param.restart_listener   = PJ_TRUE;
 
@@ -228,16 +232,17 @@ and per-account media (RTP/RTCP):
 
    // PJSUA2 — call before recreating SIP transport / modifying account.
    const std::string new_local_ip = "10.0.0.5";
+   Endpoint &ep = Endpoint::instance();
 
    // SIP transport: pass on the TransportConfig at transportCreate() time.
    TransportConfig sip_tp_cfg;
    sip_tp_cfg.boundAddress = new_local_ip;
-   ep.transportDestroy(old_sip_tp_id);
+   ep.transportClose(old_sip_tp_id);
    ep.transportCreate(PJSIP_TRANSPORT_UDP, sip_tp_cfg);
 
    // Media (RTP/RTCP): on the account config, then re-apply.
    acc_cfg.mediaConfig.transportConfig.boundAddress = new_local_ip;
-   acc->modify(acc_cfg);
+   account.modify(acc_cfg);
 
    ep.handleIpChange(IpChangeParam());
 


### PR DESCRIPTION
## Summary

Substantial rewrite of the existing IP-change guide (`specific-guides/network_nat/ip_change.rst`). Flips to PJSUA2-first and folds in coverage of post-2.7 additions that weren't documented:

- **High-level flow** — all five steps named with the IpChangeParam / AccountIpChangeConfig fields driving each.
- **Tuning for fast switching (mobile)** — three delay sources (stale TCP/TLS sockets, stale UDP listener, REGISTER on dead transport) and the knobs that address them: `shutdownTransport` ([pjproject#3781](https://github.com/pjsip/pjproject/pull/3781), default `true`), `restartListener` side-effects, `disableRegOnModify` ([pjproject#3910](https://github.com/pjsip/pjproject/pull/3910)), `reinvUseUpdate` ([pjproject#3146](https://github.com/pjsip/pjproject/pull/3146)).
- **Precondition** — call `handleIpChange` after the new network is up, not on the old-interface-down event.
- **`bound_addr` and OS routing** — how literal-IP binding indirectly pins the outbound interface, EADDRNOTAVAIL trap when the bound IP disappears, Android `ConnectivityManager.bindProcessToNetwork` interaction. Short code samples for SIP and per-account media (rtp_cfg) in both PJSUA2 and PJSUA-LIB.
- **Listener restart caveats** — bound-address-reset-to-wildcard ([pjproject#3873](https://github.com/pjsip/pjproject/pull/3873)), restart-retry semantics.
- **Maintaining a call** — re-INVITE vs UPDATE clarified (both carry SDP offer/answer; UPDATE is a generally lighter exchange per RFC 3311).
- **Optional listener-disable macros** — `PJSIP_TCP_TRANSPORT_DONT_CREATE_LISTENER` / `PJSIP_TLS_TRANSPORT_DONT_CREATE_LISTENER` for client-only builds.
- **Diagnostics** — progress-callback events and the level-3/4 log lines `pjsua_core.c` emits.
- **PJSUA-LIB equivalents table** at the bottom.

No submodule pin change. All referenced features are in pjproject 2.17 or earlier; the docs build on RTD checks out pjproject master at build time, so the new symbols (`AccountIpChangeConfig`, `IpChangeParam`, etc.) resolve there.

## Test plan

- [x] Local `sphinx-build -b html` — clean; no warnings in the new file (the two unrelated `samples.rst` / `pjsua.rst` warnings are pre-existing).
- [x] Equivalents table renders (10 data rows).
- [x] Code-claim audit against pjproject master: doxygen on all referenced PJSUA-LIB / PJSUA2 fields (`pjsua_ip_change_param`, `pjsua_ip_change_acc_cfg`, `IpChangeParam`, `AccountIpChangeConfig`), `pjsua_handle_ip_change` flow, log lines, `DONT_CREATE_LISTENER` macros, restart-listener semantics.
- [x] Self-review pass that caught: claim that `shutdown_transport` "is helpful for recreating transports" was misleading (removed); restart-listener retry trigger was over-specific to EADDRINUSE (actually any non-success status); UPDATE-vs-re-INVITE wording (corrected — both carry SDP, UPDATE is lighter, not "dialog-state-affecting").
- [ ] Reviewer to check RTD preview for the rendered page.